### PR TITLE
Add PHP connection and listing scripts

### DIFF
--- a/db.php
+++ b/db.php
@@ -1,0 +1,11 @@
+<?php
+function getDatabaseConnection($path = 'metadata.db') {
+    try {
+        $pdo = new PDO('sqlite:' . $path);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        return $pdo;
+    } catch (PDOException $e) {
+        die('Connection failed: ' . $e->getMessage());
+    }
+}
+?>

--- a/list_books.php
+++ b/list_books.php
@@ -1,0 +1,14 @@
+<?php
+require_once 'db.php';
+
+$pdo = getDatabaseConnection();
+
+try {
+    $stmt = $pdo->query('SELECT id, title FROM books ORDER BY title');
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        echo $row['id'] . " - " . $row['title'] . "\n";
+    }
+} catch (PDOException $e) {
+    echo 'Query failed: ' . $e->getMessage();
+}
+?>


### PR DESCRIPTION
## Summary
- add a helper `getDatabaseConnection` to open the SQLite Calibre DB
- list all books in `list_books.php`

## Testing
- `php -l db.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_6880ca45bd588329ad2f953f1bde2e81