### PR TITLE
Add series index to book list

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -13,7 +13,7 @@ try {
     $offset = ($page - 1) * $perPage;
 
     $stmt = $pdo->prepare(
-        'SELECT b.id, b.title, b.path, b.has_cover,
+        'SELECT b.id, b.title, b.path, b.has_cover, b.series_index,
                 COALESCE((SELECT GROUP_CONCAT(a.name, ", ")
                           FROM books_authors_link bal
                           JOIN authors a ON bal.author = a.id
@@ -53,7 +53,7 @@ $totalPages = max(1, ceil($totalBooks / $perPage));
                 <th>Cover</th>
                 <th>Title</th>
                 <th>Author(s)</th>
-                <th>Series</th>
+                <th>Series (No.)</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -70,7 +70,16 @@ $totalPages = max(1, ceil($totalBooks / $perPage));
                 </td>
                 <td><?= htmlspecialchars($book['title']) ?></td>
                 <td><?= htmlspecialchars($book['authors']) ?></td>
-                <td><?= htmlspecialchars($book['series']) ?></td>
+                <td>
+                    <?php if (!empty($book['series'])): ?>
+                        <?= htmlspecialchars($book['series']) ?>
+                        <?php if ($book['series_index'] !== null && $book['series_index'] !== ''): ?>
+                            (<?= htmlspecialchars($book['series_index']) ?>)
+                        <?php endif; ?>
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                </td>
                 <td>
                     <a class="btn btn-sm btn-primary" href="edit_book.php?id=<?= urlencode($book['id']) ?>">View / Edit</a>
                 </td>

--- a/schema.sql
+++ b/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE books ( id      INTEGER PRIMARY KEY AUTOINCREMENT,
                              sort      TEXT COLLATE NOCASE,
                              timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                              pubdate   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                             series_index REAL NOT NULL DEFAULT 1.0,
+                             series_index REAL NOT NULL DEFAULT 1.0, -- position of the book within its series
                              author_sort TEXT COLLATE NOCASE,
                              isbn TEXT DEFAULT "" COLLATE NOCASE,
                              lccn TEXT DEFAULT "" COLLATE NOCASE,


### PR DESCRIPTION
## Summary
- show series index in book listings
- document `series_index` column in `schema.sql`

## Testing
- `php -l list_books.php`
- `php -l edit_book.php`
- `php -l db.php`


------
https://chatgpt.com/codex/tasks/task_e_6880d45ce2d08329aa048c934d2a0c3e