### PR TITLE
Add book detail overview page

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -160,7 +160,9 @@ $baseUrl .= '&page=';
                 <td><?= htmlspecialchars($book['id']) ?></td>
                 <td>
                     <?php if (!empty($book['has_cover'])): ?>
-                        <img src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" alt="Cover" class="img-thumbnail" style="width: 50px; height: auto;">
+                        <a href="view_book.php?id=<?= urlencode($book['id']) ?>">
+                            <img src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" alt="Cover" class="img-thumbnail" style="width: 50px; height: auto;">
+                        </a>
                     <?php else: ?>
                         &mdash;
                     <?php endif; ?>

--- a/view_book.php
+++ b/view_book.php
@@ -1,0 +1,124 @@
+<?php
+require_once 'db.php';
+
+$pdo = getDatabaseConnection();
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($id <= 0) {
+    die('Invalid book ID');
+}
+
+$sort = $_GET['sort'] ?? 'title';
+
+$stmt = $pdo->prepare("SELECT b.*, 
+        (SELECT GROUP_CONCAT(a.name, ', ')
+            FROM books_authors_link bal
+            JOIN authors a ON bal.author = a.id
+            WHERE bal.book = b.id) AS authors,
+        (SELECT GROUP_CONCAT(a.id || ':' || a.name, '|')
+            FROM books_authors_link bal
+            JOIN authors a ON bal.author = a.id
+            WHERE bal.book = b.id) AS author_data,
+        s.id AS series_id,
+        s.name AS series
+    FROM books b
+    LEFT JOIN books_series_link bsl ON bsl.book = b.id
+    LEFT JOIN series s ON bsl.series = s.id
+    WHERE b.id = :id");
+$stmt->bindValue(':id', $id, PDO::PARAM_INT);
+$stmt->execute();
+$book = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$book) {
+    die('Book not found');
+}
+
+$commentStmt = $pdo->prepare('SELECT text FROM comments WHERE book = ?');
+$commentStmt->execute([$id]);
+$comment = $commentStmt->fetchColumn();
+
+$tagsStmt = $pdo->prepare("SELECT GROUP_CONCAT(t.name, ', ')
+    FROM books_tags_link btl
+    JOIN tags t ON btl.tag = t.id
+    WHERE btl.book = ?");
+$tagsStmt->execute([$id]);
+$tags = $tagsStmt->fetchColumn();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($book['title']) ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+</head>
+<body>
+<div class="container my-4">
+    <a href="list_books.php" class="btn btn-secondary mb-3">Back to list</a>
+    <h1 class="mb-4"><?= htmlspecialchars($book['title']) ?></h1>
+    <div class="row mb-4">
+        <div class="col-md-3">
+            <?php if (!empty($book['has_cover'])): ?>
+                <img src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" alt="Cover" class="img-fluid">
+            <?php else: ?>
+                <div class="text-muted">No cover</div>
+            <?php endif; ?>
+        </div>
+        <div class="col-md-9">
+            <p><strong>Author(s):</strong>
+                <?php if (!empty($book['author_data'])): ?>
+                    <?php
+                        $links = [];
+                        foreach (explode('|', $book['author_data']) as $pair) {
+                            list($aid, $aname) = explode(':', $pair, 2);
+                            $url = 'list_books.php?sort=' . urlencode($sort) . '&author_id=' . urlencode($aid);
+                            $links[] = '<a href="' . htmlspecialchars($url) . '">' . htmlspecialchars($aname) . '</a>';
+                        }
+                        echo implode(', ', $links);
+                    ?>
+                <?php else: ?>
+                    &mdash;
+                <?php endif; ?>
+            </p>
+            <p><strong>Series:</strong>
+                <?php if (!empty($book['series'])): ?>
+                    <a href="list_books.php?sort=<?= urlencode($sort) ?>&series_id=<?= urlencode($book['series_id']) ?>">
+                        <?= htmlspecialchars($book['series']) ?>
+                    </a>
+                    <?php if ($book['series_index'] !== null && $book['series_index'] !== ''): ?>
+                        (<?= htmlspecialchars($book['series_index']) ?>)
+                    <?php endif; ?>
+                <?php else: ?>
+                    &mdash;
+                <?php endif; ?>
+            </p>
+            <?php if (!empty($tags)): ?>
+                <p><strong>Tags:</strong> <?= htmlspecialchars($tags) ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+    <?php if (!empty($comment)): ?>
+        <div class="mb-4">
+            <h2>Description</h2>
+            <p><?= nl2br(htmlspecialchars($comment)) ?></p>
+        </div>
+    <?php endif; ?>
+    <h2>Metadata</h2>
+    <table class="table table-bordered">
+        <tr><th>ID</th><td><?= htmlspecialchars($book['id']) ?></td></tr>
+        <tr><th>Title</th><td><?= htmlspecialchars($book['title']) ?></td></tr>
+        <tr><th>Sort</th><td><?= htmlspecialchars($book['sort']) ?></td></tr>
+        <tr><th>Timestamp</th><td><?= htmlspecialchars($book['timestamp']) ?></td></tr>
+        <tr><th>Pubdate</th><td><?= htmlspecialchars($book['pubdate']) ?></td></tr>
+        <tr><th>Author Sort</th><td><?= htmlspecialchars($book['author_sort']) ?></td></tr>
+        <tr><th>ISBN</th><td><?= htmlspecialchars($book['isbn']) ?></td></tr>
+        <tr><th>LCCN</th><td><?= htmlspecialchars($book['lccn']) ?></td></tr>
+        <tr><th>Path</th><td><?= htmlspecialchars($book['path']) ?></td></tr>
+        <tr><th>Flags</th><td><?= htmlspecialchars($book['flags']) ?></td></tr>
+        <tr><th>UUID</th><td><?= htmlspecialchars($book['uuid']) ?></td></tr>
+        <tr><th>Has Cover</th><td><?= htmlspecialchars($book['has_cover']) ?></td></tr>
+        <tr><th>Last Modified</th><td><?= htmlspecialchars($book['last_modified']) ?></td></tr>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link book covers on list page to new view page
- implement `view_book.php` to display book metadata, series, authors, tags, and description

## Testing
- `php -l list_books.php`
- `php -l view_book.php`
- `php -l edit_book.php`


------
https://chatgpt.com/codex/tasks/task_e_6880fc5492c88329971d6bd06cd44314