### PR TITLE
Add book recommendation button

### DIFF
--- a/python/book_recommend.py
+++ b/python/book_recommend.py
@@ -1,5 +1,6 @@
 import requests
 import os
+import sys
 
 # Set your OpenRouter API key (or set as an environment variable)
 API_KEY = os.getenv("OPENROUTER_API_KEY", "your_api_key_here")
@@ -40,8 +41,14 @@ def get_book_recommendations(user_preferences):
     return data["choices"][0]["message"]["content"].strip()
 
 if __name__ == "__main__":
-    # Change this string to test different preferences
-    user_input = "fantasy novels like 'The Name of the Wind' and 'Mistborn'"
+    # Accept the author name and book title from the command line
+    if len(sys.argv) >= 3:
+        user_input = f"{sys.argv[1]} {sys.argv[2]}"
+    elif len(sys.argv) == 2:
+        user_input = sys.argv[1]
+    else:
+        user_input = "fantasy novels like 'The Name of the Wind' and 'Mistborn'"
+
     recommendations = get_book_recommendations(user_input)
     print("\nBook Recommendations:\n")
     print(recommendations)

--- a/view_book.php
+++ b/view_book.php
@@ -42,6 +42,14 @@ $tagsStmt = $pdo->prepare("SELECT GROUP_CONCAT(t.name, ', ')
     WHERE btl.book = ?");
 $tagsStmt->execute([$id]);
 $tags = $tagsStmt->fetchColumn();
+
+$recommendations = null;
+if (isset($_GET['recommend'])) {
+    $cmd = 'direnv exec ./python python3 ./python/book_recommend.py '
+        . escapeshellarg($book['authors']) . ' '
+        . escapeshellarg($book['title']);
+    $recommendations = shell_exec($cmd);
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -55,6 +63,11 @@ $tags = $tagsStmt->fetchColumn();
 <div class="container my-4">
     <a href="list_books.php" class="btn btn-secondary mb-3">Back to list</a>
     <h1 class="mb-4"><?= htmlspecialchars($book['title']) ?></h1>
+    <form method="get" class="mb-4">
+        <input type="hidden" name="id" value="<?= htmlspecialchars($book['id']) ?>">
+        <input type="hidden" name="sort" value="<?= htmlspecialchars($sort) ?>">
+        <button type="submit" name="recommend" value="1" class="btn btn-primary">Get Book Recommendations</button>
+    </form>
     <div class="row mb-4">
         <div class="col-md-3">
             <?php if (!empty($book['has_cover'])): ?>
@@ -100,6 +113,12 @@ $tags = $tagsStmt->fetchColumn();
         <div class="mb-4">
             <h2>Description</h2>
             <p><?= nl2br(htmlspecialchars($comment)) ?></p>
+        </div>
+<?php endif; ?>
+    <?php if ($recommendations !== null): ?>
+        <div class="mb-4">
+            <h2>Recommended Books</h2>
+            <pre><?= htmlspecialchars($recommendations) ?></pre>
         </div>
     <?php endif; ?>
     <h2>Metadata</h2>


### PR DESCRIPTION
## Summary
- allow passing author and title to `book_recommend.py`
- add button on the book view page to fetch recommendations
- show results on the page

## Testing
- `python3 -m py_compile python/book_recommend.py`
- `php -l view_book.php`
- `php -l direnv.php`


------
https://chatgpt.com/codex/tasks/task_e_6880ffb24d088329ad27f452d20666b9