### PR TITLE
Enable recommendations via modal

### DIFF
--- a/recommend.php
+++ b/recommend.php
@@ -1,0 +1,25 @@
+<?php
+header('Content-Type: application/json');
+
+$authors = $_GET['authors'] ?? '';
+$title = $_GET['title'] ?? '';
+
+if ($authors === '' && $title === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing parameters']);
+    exit;
+}
+
+$cmd = 'python3 ' . escapeshellarg(__DIR__ . '/python/book_recommend.py') . ' '
+    . escapeshellarg($authors) . ' ' . escapeshellarg($title);
+
+$output = shell_exec($cmd);
+
+if ($output === null) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to execute recommendation script']);
+    exit;
+}
+
+echo json_encode(['output' => $output]);
+


### PR DESCRIPTION
## Summary
- show recommended book output in a Bootstrap modal
- allow asynchronous recommendation via new endpoint

## Testing
- `php -l view_book.php`
- `php -l recommend.php`


------
https://chatgpt.com/codex/tasks/task_e_688101c296ec8329bb853ef2720c4502