### PR TITLE
Fix script path in recommend.php

### DIFF
--- a/recommend.php
+++ b/recommend.php
@@ -10,7 +10,8 @@ if ($authors === '' && $title === '') {
     exit;
 }
 
-$cmd = 'python3 ' . escapeshellarg(__DIR__ . '/python/book_recommend.py') . ' '
+$cmd = 'direnv exec ./python python3 '
+    . escapeshellarg(__DIR__ . '/python/book_recommend.py') . ' '
     . escapeshellarg($authors) . ' ' . escapeshellarg($title);
 
 $output = shell_exec($cmd);


### PR DESCRIPTION
## Summary
- call Python recommendation script through direnv to ensure correct environment

## Testing
- `php -l recommend.php`

------
https://chatgpt.com/codex/tasks/task_e_6881054546bc8329ae310e59aeaf4168