### PR TITLE
Store recommendations in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SQLite Books
 
-This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API.
+This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `custom_column_10` table so they can be referenced later.
 
 To enable the recommendation feature, set the `OPENROUTER_API_KEY` environment variable with your API key. The `recommend.php` endpoint calls `get_book_recommendations()` defined in `book_recommend.php` to contact the API and return results.

--- a/recommend.php
+++ b/recommend.php
@@ -2,9 +2,11 @@
 header('Content-Type: application/json');
 
 require_once 'book_recommend.php';
+require_once 'db.php';
 
 $authors = $_GET['authors'] ?? '';
 $title = $_GET['title'] ?? '';
+$bookId = isset($_GET['book_id']) ? (int)$_GET['book_id'] : 0;
 
 if ($authors === '' && $title === '') {
     http_response_code(400);
@@ -16,6 +18,13 @@ $userInput = trim($authors . ' ' . $title);
 
 try {
     $output = get_book_recommendations($userInput);
+
+    if ($bookId > 0) {
+        $pdo = getDatabaseConnection();
+        $stmt = $pdo->prepare('REPLACE INTO custom_column_10 (book, value) VALUES (:book, :value)');
+        $stmt->execute([':book' => $bookId, ':value' => $output]);
+    }
+
     echo json_encode(['output' => $output]);
 } catch (Exception $e) {
     http_response_code(500);

--- a/view_book.php
+++ b/view_book.php
@@ -55,7 +55,7 @@ $tags = $tagsStmt->fetchColumn();
 <div class="container my-4">
     <a href="list_books.php" class="btn btn-secondary mb-3">Back to list</a>
     <h1 class="mb-4"><?= htmlspecialchars($book['title']) ?></h1>
-    <button type="button" id="recommendBtn" data-authors="<?= htmlspecialchars($book['authors']) ?>" data-title="<?= htmlspecialchars($book['title']) ?>" class="btn btn-primary mb-4">Get Book Recommendations</button>
+    <button type="button" id="recommendBtn" data-book-id="<?= htmlspecialchars($book['id']) ?>" data-authors="<?= htmlspecialchars($book['authors']) ?>" data-title="<?= htmlspecialchars($book['title']) ?>" class="btn btn-primary mb-4">Get Book Recommendations</button>
     <div class="row mb-4">
         <div class="col-md-3">
             <?php if (!empty($book['has_cover'])): ?>
@@ -147,13 +147,15 @@ const recommendModalEl = document.getElementById('recommendModal');
 const recommendModal = new bootstrap.Modal(recommendModalEl);
 
 recommendBtn.addEventListener('click', function () {
+    const bookId = this.dataset.bookId;
     const authors = this.dataset.authors;
     const title = this.dataset.title;
     recommendContent.textContent = '';
     recommendLoading.style.display = 'block';
     recommendModal.show();
 
-    fetch('recommend.php?authors=' + encodeURIComponent(authors) + '&title=' + encodeURIComponent(title))
+    fetch('recommend.php?book_id=' + encodeURIComponent(bookId) +
+        '&authors=' + encodeURIComponent(authors) + '&title=' + encodeURIComponent(title))
         .then(resp => resp.json())
         .then(data => {
             recommendLoading.style.display = 'none';


### PR DESCRIPTION
## Summary
- capture book id on the recommendations button
- send `book_id` to `recommend.php`
- store recommendation output in `custom_column_10`
- update README about saving recommendations

## Testing
- `php -l recommend.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_68813110fc948329ae95183c9e28e714