### PR TITLE
Add author autocomplete search

### DIFF
--- a/author_autocomplete.php
+++ b/author_autocomplete.php
@@ -1,0 +1,20 @@
+<?php
+require_once 'db.php';
+header('Content-Type: application/json');
+
+$term = isset($_GET['term']) ? trim((string)$_GET['term']) : '';
+if ($term === '') {
+    echo json_encode([]);
+    exit;
+}
+
+try {
+    $pdo = getDatabaseConnection();
+    $stmt = $pdo->prepare('SELECT name FROM authors WHERE name LIKE :term || "%" ORDER BY name LIMIT 10');
+    $stmt->execute([':term' => $term]);
+    $names = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    echo json_encode($names);
+} catch (PDOException $e) {
+    echo json_encode([]);
+}
+

--- a/list_books.php
+++ b/list_books.php
@@ -139,6 +139,9 @@ $baseUrl .= '&page=';
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Book List</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js" crossorigin="anonymous"></script>
 </head>
 <body>
 <div class="container my-4">
@@ -331,5 +334,19 @@ $baseUrl .= '&page=';
     </nav>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+$(function() {
+    var $searchInput = $('input[name="search"]');
+    $searchInput.autocomplete({
+        source: function(request, response) {
+            $.getJSON('author_autocomplete.php', { term: request.term }, function(data) {
+                response(data);
+            });
+        },
+        minLength: 2
+    });
+});
+</script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add an endpoint `author_autocomplete.php` to provide author suggestions
- include jQuery UI on `list_books.php`
- hook search box up to autocomplete using the new endpoint

## Testing
- `php -l list_books.php`
- `php -l author_autocomplete.php`


------
https://chatgpt.com/codex/tasks/task_e_6881500e386c8329a3ec392a6d12e9a4