### PR TITLE
Add OpenLibrary details page

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -256,7 +256,11 @@ $baseUrl .= '&page=';
                         &mdash;
                     <?php endif; ?>
                 </td>
-                <td><?= htmlspecialchars($book['title']) ?></td>
+                <td>
+                    <a href="openlibrary_view.php?key=<?= urlencode($book['key']) ?>&title=<?= urlencode($book['title']) ?>&authors=<?= urlencode($book['authors']) ?>&cover_id=<?= urlencode((string)$book['cover_id']) ?>">
+                        <?= htmlspecialchars($book['title']) ?>
+                    </a>
+                </td>
                 <td><?= $book['authors'] !== '' ? htmlspecialchars($book['authors']) : '&mdash;' ?></td>
                 <td>&mdash;</td>
                 <td>&mdash;</td>

--- a/openlibrary.php
+++ b/openlibrary.php
@@ -23,9 +23,61 @@ function search_openlibrary(string $query): array {
         $results[] = [
             'title' => $doc['title'] ?? '',
             'authors' => isset($doc['author_name']) ? implode(', ', (array)$doc['author_name']) : '',
-            'cover_id' => $doc['cover_i'] ?? null
+            'cover_id' => $doc['cover_i'] ?? null,
+            'key' => $doc['key'] ?? ''
         ];
     }
     return $results;
+}
+
+function get_openlibrary_work(string $key): array {
+    $key = trim($key);
+    if ($key === '') {
+        return [];
+    }
+    // Ensure the key starts with '/works/'
+    if (strpos($key, '/works/') !== 0) {
+        $key = '/works/' . ltrim($key, '/');
+    }
+    $url = 'https://openlibrary.org' . $key . '.json';
+
+    $options = [
+        'http' => [
+            'method' => 'GET',
+            'header' => [
+                'Accept: application/json'
+            ]
+        ]
+    ];
+    $context = stream_context_create($options);
+    $json = @file_get_contents($url, false, $context);
+    if ($json === false) {
+        return [];
+    }
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return [];
+    }
+
+    $description = '';
+    if (isset($data['description'])) {
+        if (is_array($data['description'])) {
+            $description = $data['description']['value'] ?? '';
+        } elseif (is_string($data['description'])) {
+            $description = $data['description'];
+        }
+    }
+
+    $subjects = [];
+    if (!empty($data['subjects']) && is_array($data['subjects'])) {
+        $subjects = $data['subjects'];
+    }
+
+    return [
+        'title' => $data['title'] ?? '',
+        'description' => $description,
+        'subjects' => $subjects,
+        'covers' => $data['covers'] ?? []
+    ];
 }
 ?>

--- a/openlibrary_view.php
+++ b/openlibrary_view.php
@@ -1,0 +1,55 @@
+<?php
+require_once 'openlibrary.php';
+
+$key = isset($_GET['key']) ? trim((string)$_GET['key']) : '';
+$title = isset($_GET['title']) ? (string)$_GET['title'] : '';
+$authors = isset($_GET['authors']) ? (string)$_GET['authors'] : '';
+$coverId = isset($_GET['cover_id']) ? (string)$_GET['cover_id'] : '';
+
+$work = [];
+if ($key !== '') {
+    $work = get_openlibrary_work($key);
+}
+
+$workTitle = $work['title'] ?? $title;
+$description = $work['description'] ?? '';
+$subjects = $work['subjects'] ?? [];
+$covers = $work['covers'] ?? [];
+if (!$coverId && !empty($covers)) {
+    $coverId = (string)($covers[0]);
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($workTitle) ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+</head>
+<body>
+<div class="container my-4">
+    <a href="javascript:history.back()" class="btn btn-secondary mb-3">Back</a>
+    <h1 class="mb-4"><?= htmlspecialchars($workTitle) ?></h1>
+    <div class="row mb-4">
+        <div class="col-md-3">
+            <?php if ($coverId): ?>
+                <img src="https://covers.openlibrary.org/b/id/<?= htmlspecialchars($coverId) ?>-L.jpg" class="img-fluid" alt="Cover">
+            <?php endif; ?>
+        </div>
+        <div class="col-md-9">
+            <?php if ($authors !== ''): ?>
+                <p><strong>Author(s):</strong> <?= htmlspecialchars($authors) ?></p>
+            <?php endif; ?>
+            <?php if ($description !== ''): ?>
+                <p><?= nl2br(htmlspecialchars($description)) ?></p>
+            <?php endif; ?>
+            <?php if (!empty($subjects)): ?>
+                <p><strong>Subjects:</strong> <?= htmlspecialchars(implode(', ', $subjects)) ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include work `key` in `search_openlibrary`
- add helper `get_openlibrary_work` for metadata lookup
- link titles in Open Library search results to a new page
- create `openlibrary_view.php` to display Open Library book details

## Testing
- `php -l openlibrary.php`
- `php -l openlibrary_view.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_6881609e2a6c83298001a0ed0ffd84fe