### PR TITLE
Add recommendation parsing with Open Library links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@ This project is a small PHP application for browsing and editing an eBook databa
 
 Use the search bar at the top of `list_books.php` to search for books by title or author name. A dropdown next to the search field lets you choose between searching the **local** Calibre database or querying the **Open Library** API. Results from Open Library are shown in the same table layout but without local-only actions.
 
+When viewing a book you can click **Get Book Recommendations**. The returned text is parsed to identify
+the recommended title and author. Each title links back to `list_books.php` with an Open Library search
+so you can quickly explore more details about that book.
+
 To enable the recommendation feature, set the `OPENROUTER_API_KEY` environment variable with your API key. The `recommend.php` endpoint calls `get_book_recommendations()` defined in `book_recommend.php` to contact the API and return results.


### PR DESCRIPTION
## Summary
- parse saved and fetched recommendations to grab title and author
- render recommendations as linked list items leading to Open Library searches
- document recommendation link feature in README

## Testing
- `php -l recommend.php`
- `php -l book_recommend.php`
- `php -l db.php`
- `php -l author_autocomplete.php`
- `php -l edit_book.php`
- `php -l list_books.php`
- `php -l openlibrary.php`
- `php -l openlibrary_view.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_688173ad4b588329b9eacec9cc168d69