### PR TITLE
Fix recommendation link rendering

### DIFF
--- a/view_book.php
+++ b/view_book.php
@@ -155,14 +155,21 @@ function parseRecommendations(text) {
     const recs = [];
     for (let line of lines) {
         line = line.replace(/^\d+\.\s*/, '').replace(/^[-*]\s*/, '');
-        const match = line.match(/\*?"?([^"\*]+)"?\*?\s+by\s+([^\-]+?)(?:\s+-\s+(.*))?$/i);
-        if (match) {
-            recs.push({
-                title: match[1].trim(),
-                author: match[2].trim(),
-                reason: match[3] ? match[3].trim() : ''
-            });
+        const byPos = line.toLowerCase().indexOf(' by ');
+        if (byPos === -1) continue;
+        let title = line.slice(0, byPos).trim();
+        title = title.replace(/^['"*_]+|['"*_]+$/g, '');
+        let rest = line.slice(byPos + 4).trim();
+        let author, reason = '';
+        const dashPos = rest.indexOf(' - ');
+        if (dashPos !== -1) {
+            author = rest.slice(0, dashPos).trim();
+            reason = rest.slice(dashPos + 3).trim();
+        } else {
+            author = rest;
         }
+        author = author.replace(/^['"*_]+|['"*_]+$/g, '');
+        recs.push({ title, author, reason });
     }
     return recs;
 }


### PR DESCRIPTION
## Summary
- robustly parse recommendation lines with varying formatting

## Testing
- `php -l view_book.php`
- `for f in *.php; do php -l "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_6881785d60a483299497906b0b17e58f