### PR TITLE
Add shelf management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `books_custom_column_10` table so they can be referenced later.
 
-Each book also has a "Shelf" value stored in the `books_custom_column_11` table.  The
-options are **Physical**, **Ebook Calibre**, and **PDFs**.  When listing books a
-dropdown next to each entry allows changing the shelf.  All books default to
-`Ebook Calibre` if no explicit value is set.
+Each book also has a "Shelf" value stored in the `books_custom_column_11` table.
+Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
 ## Searching
 

--- a/add_shelf.php
+++ b/add_shelf.php
@@ -1,0 +1,27 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$shelf = trim($_POST['shelf'] ?? '');
+if ($shelf === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid shelf']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare('CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)');
+    $stmt->execute();
+    $defaults = ['Physical', 'Ebook Calibre', 'PDFs'];
+    foreach ($defaults as $d) {
+        $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$d]);
+    }
+    $stmt = $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (:name)');
+    $stmt->execute([':name' => $shelf]);
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/delete_shelf.php
+++ b/delete_shelf.php
@@ -1,0 +1,23 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$shelf = trim($_POST['shelf'] ?? '');
+if ($shelf === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid shelf']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare('DELETE FROM shelves WHERE name = :name');
+    $stmt->execute([':name' => $shelf]);
+    $update = $pdo->prepare("UPDATE books_custom_column_11 SET value = 'Ebook Calibre' WHERE value = :name");
+    $update->execute([':name' => $shelf]);
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/update_shelf.php
+++ b/update_shelf.php
@@ -5,16 +5,22 @@ require_once 'db.php';
 $bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
 $value = $_POST['value'] ?? '';
 
-$allowed = ['Physical', 'Ebook Calibre', 'PDFs'];
+$pdo = getDatabaseConnection();
+$pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
+$defaults = ['Physical', 'Ebook Calibre', 'PDFs'];
+foreach ($defaults as $d) {
+    $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$d]);
+}
+$allowed = $pdo->query('SELECT name FROM shelves')->fetchAll(PDO::FETCH_COLUMN);
+
 if ($bookId <= 0 || !in_array($value, $allowed, true)) {
     http_response_code(400);
     echo json_encode(['error' => 'Invalid input']);
     exit;
 }
 
-$pdo = getDatabaseConnection();
 $stmt = $pdo->prepare('REPLACE INTO books_custom_column_11 (book, value) VALUES (:book, :value)');
 $stmt->execute([':book' => $bookId, ':value' => $value]);
 
 echo json_encode(['status' => 'ok']);
-
+?>


### PR DESCRIPTION
## Summary
- manage shelf names in new `shelves` table
- render shelf list with add/remove controls in sidebar
- update shelf dropdowns to use dynamic shelf list
- adjust shelf update endpoint
- document the new shelf feature

## Testing
- `php -l add_shelf.php`
- `php -l delete_shelf.php`
- `php -l update_shelf.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_68818b7b24f083299db4d85b671caa49