### PR TITLE
Enable shelf filtering via sidebar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `books_custom_column_10` table so they can be referenced later.
 
-Each book also has a "Shelf" value stored in the `books_custom_column_11` table.
-Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
+Each book also has a "Shelf" value stored in the `books_custom_column_11` table. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
 ## Searching
 


### PR DESCRIPTION
## Summary
- make shelf names into links so they filter books
- support filtering by shelf name in `list_books.php`
- persist shelf filters in forms and infinite scroll
- document clickable shelves in `README`

## Testing
- `php -l list_books.php`
- `for f in *.php; do php -l "$f" || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_68818d523b7c832981546955c8b9a6ff