### PR TITLE
Add Open Library import feature

### DIFF
--- a/add_book.php
+++ b/add_book.php
@@ -1,0 +1,57 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$title = trim($_POST['title'] ?? '');
+$authors = trim($_POST['authors'] ?? '');
+if ($title === '' || $authors === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing parameters']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+
+try {
+    $pdo->beginTransaction();
+
+    $primaryAuthor = trim(explode(',', $authors)[0]);
+    $stmt = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (:name, :sort)');
+    $stmt->execute([':name' => $primaryAuthor, ':sort' => $primaryAuthor]);
+
+    $stmt = $pdo->prepare('SELECT id FROM authors WHERE name = :name');
+    $stmt->execute([':name' => $primaryAuthor]);
+    $authorId = (int)$stmt->fetchColumn();
+
+    $path = preg_replace('/[^A-Za-z0-9]+/', '_', $title);
+    $insertBook = $pdo->prepare('INSERT INTO books (title, sort, author_sort, timestamp, pubdate, series_index, last_modified, path)
+                                 VALUES (:title, :sort, :author_sort, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1.0, CURRENT_TIMESTAMP, :path)');
+    $insertBook->execute([
+        ':title' => $title,
+        ':sort' => $title,
+        ':author_sort' => $primaryAuthor,
+        ':path' => $path
+    ]);
+    $bookId = (int)$pdo->lastInsertId();
+
+    $balStmt = $pdo->prepare('INSERT INTO books_authors_link (book, author) VALUES (:book, :author)');
+    $balStmt->execute([':book' => $bookId, ':author' => $authorId]);
+
+    $tableStmt = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'books_custom_column_%' AND name NOT LIKE '%_link'");
+    $tables = $tableStmt->fetchAll(PDO::FETCH_COLUMN);
+    foreach ($tables as $table) {
+        $value = null;
+        if ($table === 'books_custom_column_11') {
+            $value = 'Physical';
+        }
+        $pdo->prepare("INSERT INTO $table (book, value) VALUES (:book, :value)")->execute([':book' => $bookId, ':value' => $value]);
+    }
+
+    $pdo->commit();
+    echo json_encode(['status' => 'ok', 'book_id' => $bookId]);
+} catch (PDOException $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+

--- a/openlibrary_view.php
+++ b/openlibrary_view.php
@@ -47,9 +47,40 @@ if (!$coverId && !empty($covers)) {
             <?php if (!empty($subjects)): ?>
                 <p><strong>Subjects:</strong> <?= htmlspecialchars(implode(', ', $subjects)) ?></p>
             <?php endif; ?>
+            <button id="addBtn" type="button" class="btn btn-primary mt-3"
+                    data-title="<?= htmlspecialchars($workTitle, ENT_QUOTES) ?>"
+                    data-authors="<?= htmlspecialchars($authors, ENT_QUOTES) ?>">
+                Add to Library
+            </button>
+            <div id="addResult" class="mt-2"></div>
         </div>
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+document.getElementById('addBtn').addEventListener('click', function () {
+    const title = this.dataset.title;
+    const authors = this.dataset.authors;
+    const params = new URLSearchParams({title: title, authors: authors});
+    const resultEl = document.getElementById('addResult');
+    resultEl.textContent = 'Adding...';
+    fetch('add_book.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: params
+    })
+    .then(resp => resp.json())
+    .then(data => {
+        if (data.status === 'ok') {
+            resultEl.textContent = 'Book added to library';
+        } else {
+            resultEl.textContent = data.error || 'Error adding book';
+        }
+    })
+    .catch(() => {
+        resultEl.textContent = 'Error adding book';
+    });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `add_book.php` endpoint to insert a new book and default the shelf to `Physical`
- show **Add to Library** button in `openlibrary_view.php` and trigger the new endpoint via JavaScript

## Testing
- `php -l openlibrary_view.php`
- `php -l add_book.php`
- `for f in *.php; do php -l "$f" >/dev/null; done`

------
https://chatgpt.com/codex/tasks/task_e_688192b920e88329a7c0f3e268366f44