### PR TITLE
Add status column editing to book list

### DIFF
--- a/update_status.php
+++ b/update_status.php
@@ -1,0 +1,34 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
+$value = trim($_POST['value'] ?? '');
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt->execute();
+    $statusId = $stmt->fetchColumn();
+    if ($statusId === false) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Status column not found']);
+        exit;
+    }
+    $table = 'books_custom_column_' . (int)$statusId;
+    $pdo->exec("CREATE TABLE IF NOT EXISTS $table (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+
+    if ($bookId <= 0) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid input']);
+        exit;
+    }
+    $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :value)");
+    $stmt->execute([':book' => $bookId, ':value' => $value]);
+
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- locate the custom `status` column and load its options
- join status data when fetching books
- display a status dropdown in the book list
- update status via new `update_status.php`

## Testing
- `php -l list_books.php`
- `php -l update_status.php`

------
https://chatgpt.com/codex/tasks/task_e_6881f8190e0c83298c065da2d042e0bb