### PR TITLE
Fix status column support for Calibre schema

### DIFF
--- a/update_status.php
+++ b/update_status.php
@@ -15,16 +15,44 @@ try {
         echo json_encode(['error' => 'Status column not found']);
         exit;
     }
-    $table = 'books_custom_column_' . (int)$statusId;
-    $pdo->exec("CREATE TABLE IF NOT EXISTS $table (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+
+    $base = 'books_custom_column_' . (int)$statusId;
+    $direct = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "'")->fetchColumn();
+    $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
 
     if ($bookId <= 0) {
         http_response_code(400);
         echo json_encode(['error' => 'Invalid input']);
         exit;
     }
-    $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :value)");
-    $stmt->execute([':book' => $bookId, ':value' => $value]);
+
+    if ($link) {
+        // Enumerated column using link table
+        $table = $base . '_link';
+        $valueTable = 'custom_column_' . (int)$statusId;
+        if ($value === '') {
+            $stmt = $pdo->prepare("DELETE FROM $table WHERE book = :book");
+            $stmt->execute([':book' => $bookId]);
+        } else {
+            // Ensure value exists
+            $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+            $stmt->execute([':val' => $value]);
+            $valId = $stmt->fetchColumn();
+            if ($valId === false) {
+                $stmt = $pdo->prepare("INSERT INTO $valueTable (value) VALUES (:val)");
+                $stmt->execute([':val' => $value]);
+                $valId = $pdo->lastInsertId();
+            }
+            $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
+            $stmt->execute([':book' => $bookId, ':val' => $valId]);
+        }
+    } else {
+        // Simple text column
+        $table = $base;
+        $pdo->exec("CREATE TABLE IF NOT EXISTS $table (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+        $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :value)");
+        $stmt->execute([':book' => $bookId, ':value' => $value]);
+    }
 
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- detect if the Calibre `status` custom column uses a link table or simple table
- fetch status options appropriately and join the correct tables when listing books
- update status values correctly for both table types

## Testing
- `php -l update_status.php`
- `php -l list_books.php`
- `for f in *.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6881fc3b32988329b3b265c058d3dba2