### PR TITLE
Add status management

### DIFF
--- a/add_status.php
+++ b/add_status.php
@@ -1,0 +1,38 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$status = trim($_POST['status'] ?? '');
+if ($status === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid status']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt->execute();
+    $statusId = $stmt->fetchColumn();
+    if ($statusId === false) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Status column not found']);
+        exit;
+    }
+    $base = 'books_custom_column_' . (int)$statusId;
+    $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
+    if ($link) {
+        $valueTable = 'custom_column_' . (int)$statusId;
+        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")->execute([':val' => $status]);
+    } else {
+        // For non-enumerated columns just insert into the main table for filtering
+        $valueTable = $base;
+        $pdo->exec("CREATE TABLE IF NOT EXISTS $valueTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (book, value) SELECT id, :val FROM books WHERE 0")->execute([':val' => $status]);
+    }
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/delete_status.php
+++ b/delete_status.php
@@ -1,0 +1,44 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$status = trim($_POST['status'] ?? '');
+if ($status === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid status']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt->execute();
+    $statusId = $stmt->fetchColumn();
+    if ($statusId === false) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Status column not found']);
+        exit;
+    }
+    $base = 'books_custom_column_' . (int)$statusId;
+    $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
+    if ($link) {
+        $valueTable = 'custom_column_' . (int)$statusId;
+        $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+        $stmt->execute([':val' => $status]);
+        $valId = $stmt->fetchColumn();
+        if ($valId !== false) {
+            // ensure default exists
+            $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES ('Want to Read')")->execute();
+            $defId = $pdo->query("SELECT id FROM $valueTable WHERE value = 'Want to Read'")->fetchColumn();
+            $statusLinkTable = $base . '_link';
+            $pdo->prepare("UPDATE $statusLinkTable SET value = :def WHERE value = :old")
+                ->execute([':def' => $defId, ':old' => $valId]);
+            $pdo->prepare("DELETE FROM $valueTable WHERE id = :id")->execute([':id' => $valId]);
+        }
+    }
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- add endpoints for adding and deleting statuses
- default book status is now "Want to Read"
- show status list in sidebar with add/remove options
- include status filter in list page and support editing defaults

## Testing
- `php -l add_status.php`
- `php -l delete_status.php`
- `php -l list_books.php`
- `php -l add_book.php`


------
https://chatgpt.com/codex/tasks/task_e_6881fde4d3948329845616970e423f0e