### PR TITLE
Enable shelf and status rename

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -470,7 +470,10 @@ if ($isAjax) {
                             <?php $url = $shelfUrlBase . '&shelf=' . urlencode($s); ?>
                             <li class="list-group-item d-flex justify-content-between align-items-center<?= $shelfName === $s ? ' active' : '' ?>">
                                 <a href="<?= htmlspecialchars($url) ?>" class="flex-grow-1 me-2 text-decoration-none<?= $shelfName === $s ? ' text-white' : '' ?>"><?= htmlspecialchars($s) ?></a>
-                                <button type="button" class="btn btn-sm btn-outline-danger delete-shelf" data-shelf="<?= htmlspecialchars($s) ?>">&times;</button>
+                                <div class="btn-group btn-group-sm" role="group">
+                                    <button type="button" class="btn btn-outline-secondary edit-shelf" data-shelf="<?= htmlspecialchars($s) ?>">E</button>
+                                    <button type="button" class="btn btn-outline-danger delete-shelf" data-shelf="<?= htmlspecialchars($s) ?>">&times;</button>
+                                </div>
                             </li>
                         <?php endforeach; ?>
                     </ul>
@@ -500,7 +503,10 @@ if ($isAjax) {
                             <?php $url = $statusUrlBase . '&status=' . urlencode($s); ?>
                             <li class="list-group-item d-flex justify-content-between align-items-center<?= $statusName === $s ? ' active' : '' ?>">
                                 <a href="<?= htmlspecialchars($url) ?>" class="flex-grow-1 me-2 text-decoration-none<?= $statusName === $s ? ' text-white' : '' ?>"><?= htmlspecialchars($s) ?></a>
-                                <button type="button" class="btn btn-sm btn-outline-danger delete-status" data-status="<?= htmlspecialchars($s) ?>">&times;</button>
+                                <div class="btn-group btn-group-sm" role="group">
+                                    <button type="button" class="btn btn-outline-secondary edit-status" data-status="<?= htmlspecialchars($s) ?>">E</button>
+                                    <button type="button" class="btn btn-outline-danger delete-status" data-status="<?= htmlspecialchars($s) ?>">&times;</button>
+                                </div>
                             </li>
                         <?php endforeach; ?>
                     </ul>
@@ -742,6 +748,19 @@ $(function() {
         }).then(function() { location.reload(); });
     });
 
+    $(document).on('click', '.edit-shelf', function() {
+        var shelf = $(this).data('shelf');
+        var name = prompt('Rename shelf:', shelf);
+        if (name === null) return;
+        name = name.trim();
+        if (!name || name === shelf) return;
+        fetch('rename_shelf.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ shelf: shelf, new: name })
+        }).then(function() { location.reload(); });
+    });
+
     $(document).on('click', '.delete-status', function() {
         if (!confirm('Remove this status?')) return;
         var status = $(this).data('status');
@@ -749,6 +768,19 @@ $(function() {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: new URLSearchParams({ status: status })
+        }).then(function() { location.reload(); });
+    });
+
+    $(document).on('click', '.edit-status', function() {
+        var status = $(this).data('status');
+        var name = prompt('Rename status:', status);
+        if (name === null) return;
+        name = name.trim();
+        if (!name || name === status) return;
+        fetch('rename_status.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ status: status, new: name })
         }).then(function() { location.reload(); });
     });
 

--- a/rename_shelf.php
+++ b/rename_shelf.php
@@ -1,0 +1,27 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$old = trim($_POST['shelf'] ?? '');
+$new = trim($_POST['new'] ?? '');
+if ($old === '' || $new === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid shelf']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
+    $pdo->beginTransaction();
+    $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (:new)')->execute([':new' => $new]);
+    $pdo->prepare('UPDATE books_custom_column_11 SET value = :new WHERE value = :old')->execute([':new' => $new, ':old' => $old]);
+    $pdo->prepare('DELETE FROM shelves WHERE name = :old')->execute([':old' => $old]);
+    $pdo->commit();
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/rename_status.php
+++ b/rename_status.php
@@ -1,0 +1,57 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$old = trim($_POST['status'] ?? '');
+$new = trim($_POST['new'] ?? '');
+if ($old === '' || $new === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid status']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt->execute();
+    $statusId = $stmt->fetchColumn();
+    if ($statusId === false) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Status column not found']);
+        exit;
+    }
+    $base = 'books_custom_column_' . (int)$statusId;
+    $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
+    if ($link) {
+        $valueTable = 'custom_column_' . (int)$statusId;
+        $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+        $stmt->execute([':val' => $old]);
+        $oldId = $stmt->fetchColumn();
+        if ($oldId === false) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Status not found']);
+            exit;
+        }
+        $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+        $stmt->execute([':val' => $new]);
+        $newId = $stmt->fetchColumn();
+        if ($newId === false) {
+            $pdo->prepare("UPDATE $valueTable SET value = :new WHERE id = :id")->execute([':new' => $new, ':id' => $oldId]);
+        } else {
+            $statusLinkTable = $base . '_link';
+            $pdo->prepare("UPDATE $statusLinkTable SET value = :newid WHERE value = :oldid")
+                ->execute([':newid' => $newId, ':oldid' => $oldId]);
+            $pdo->prepare("DELETE FROM $valueTable WHERE id = :oldid")->execute([':oldid' => $oldId]);
+        }
+    } else {
+        $table = $base;
+        $pdo->exec("CREATE TABLE IF NOT EXISTS $table (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+        $pdo->prepare("UPDATE $table SET value = :new WHERE value = :old")
+            ->execute([':new' => $new, ':old' => $old]);
+    }
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- allow renaming shelves via new `rename_shelf.php`
- allow renaming statuses via new `rename_status.php`
- add edit buttons in status and shelf lists
- handle `edit-shelf` and `edit-status` actions in the JS

## Testing
- `php -l rename_shelf.php`
- `php -l rename_status.php`
- `php -l list_books.php`

------
https://chatgpt.com/codex/tasks/task_e_68820069238c832996a5fb18a0c3bf0f