### PR TITLE
Add reading challenge tracking

### DIFF
--- a/navbar.php
+++ b/navbar.php
@@ -68,6 +68,11 @@ $statusNameVal = isset($statusName) ? $statusName : '';
           <option value="recommended"<?= $sortVal === 'recommended' ? ' selected' : '' ?>>Recommended Only</option>
         </select>
       </form>
+      <ul class="navbar-nav ms-3">
+        <li class="nav-item">
+          <a class="nav-link" href="reading_challenges.php">Reading Challenge</a>
+        </li>
+      </ul>
     </div>
   </div>
 </nav>

--- a/reading_challenges.php
+++ b/reading_challenges.php
@@ -1,0 +1,60 @@
+<?php
+require_once 'db.php';
+
+$pdo = getDatabaseConnection();
+
+$year = (int)date('Y');
+$message = '';
+
+try {
+    // Ensure tables exist
+    $pdo->exec("CREATE TABLE IF NOT EXISTS reading_challenges (year INTEGER PRIMARY KEY, goal INTEGER)");
+    $pdo->exec("CREATE TABLE IF NOT EXISTS reading_log (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, year INTEGER)");
+
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $goal = isset($_POST['goal']) ? (int)$_POST['goal'] : 0;
+        if ($goal > 0) {
+            $stmt = $pdo->prepare('REPLACE INTO reading_challenges (year, goal) VALUES (:year, :goal)');
+            $stmt->execute([':year' => $year, ':goal' => $goal]);
+            $message = 'Goal saved.';
+        }
+    }
+
+    $goalStmt = $pdo->prepare('SELECT goal FROM reading_challenges WHERE year = :year');
+    $goalStmt->execute([':year' => $year]);
+    $goal = $goalStmt->fetchColumn();
+
+    $countStmt = $pdo->prepare('SELECT COUNT(*) FROM reading_log WHERE year = :year');
+    $countStmt->execute([':year' => $year]);
+    $readCount = (int)$countStmt->fetchColumn();
+} catch (PDOException $e) {
+    die('Database error: ' . $e->getMessage());
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Reading Challenge</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+</head>
+<body class="pt-5">
+<?php include "navbar.php"; ?>
+<div class="container my-4">
+    <h1 class="mb-4">Reading Challenge <?= htmlspecialchars((string)$year) ?></h1>
+    <?php if ($message): ?>
+        <div class="alert alert-success"><?= htmlspecialchars($message) ?></div>
+    <?php endif; ?>
+    <p>You have read <?= $readCount ?><?= $goal ? ' of ' . $goal : '' ?> books this year.</p>
+    <form method="post" class="mb-3">
+        <div class="input-group" style="max-width: 20rem;">
+            <label class="input-group-text" for="goal">Yearly Goal</label>
+            <input type="number" class="form-control" name="goal" id="goal" value="<?= htmlspecialchars((string)$goal) ?>" min="1">
+            <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple reading challenge page
- show link to the challenge in the navbar
- log books marked as "Read" and count them for the current year

## Testing
- `php -l navbar.php`
- `php -l update_status.php`
- `php -l reading_challenges.php`


------
https://chatgpt.com/codex/tasks/task_e_68820d710a008329bf1a60aaf428a2b6