### PR TITLE
Add Read Challenge status

### DIFF
--- a/reading_challenges.php
+++ b/reading_challenges.php
@@ -95,6 +95,7 @@ try {
                 <th>Title</th>
                 <th>Author(s)</th>
                 <th>Finished</th>
+                <th>Remove</th>
             </tr>
             </thead>
             <tbody>
@@ -116,6 +117,9 @@ try {
                             <?= htmlspecialchars(date('M j, Y', strtotime($b['read_date']))) ?>
                         <?php endif; ?>
                     </td>
+                    <td>
+                        <button class="btn btn-sm btn-danger remove-challenge" data-book-id="<?= htmlspecialchars($b['id']) ?>">Remove</button>
+                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
@@ -123,5 +127,17 @@ try {
     <?php endif; ?>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+document.querySelectorAll('.remove-challenge').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        var id = this.getAttribute('data-book-id');
+        fetch('update_status.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ book_id: id, value: 'Read' })
+        }).then(function() { location.reload(); });
+    });
+});
+</script>
 </body>
 </html>

--- a/update_status.php
+++ b/update_status.php
@@ -60,7 +60,7 @@ try {
     }
 
     $currentYear = (int)date('Y');
-    if (strcasecmp($value, 'Read') === 0) {
+    if (strcasecmp($value, 'Read Challenge') === 0) {
         $stmt = $pdo->prepare('REPLACE INTO reading_log (book, year, read_date) VALUES (:book, :year, :read_date)');
         $stmt->execute([
             ':book' => $bookId,


### PR DESCRIPTION
## Summary
- track challenge completion only when a book's status is `Read Challenge`
- allow removing a book from the challenge list

## Testing
- `php -l update_status.php`
- `php -l reading_challenges.php`


------
https://chatgpt.com/codex/tasks/task_e_6882148d65988329aa2f00eebd969764