### PR TITLE
Enable SQLite foreign key enforcement

### DIFF
--- a/db.php
+++ b/db.php
@@ -3,6 +3,8 @@ function getDatabaseConnection($path = 'metadata.old.db') {
     try {
         $pdo = new PDO('sqlite:' . $path);
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        // Enforce foreign key constraints for the connection
+        $pdo->exec('PRAGMA foreign_keys = ON');
 
         // Register a PHP implementation of Calibre's title_sort function so
         // database triggers referring to title_sort() work correctly.


### PR DESCRIPTION
## Summary
- enable foreign key enforcement in `db.php`

## Testing
- `php verify_operations.php`

------
https://chatgpt.com/codex/tasks/task_e_6882193df87c832998e3d3490547d36f