### PR TITLE
Fix duplicate books when changing status

### DIFF
--- a/update_status.php
+++ b/update_status.php
@@ -48,7 +48,9 @@ try {
                 $stmt->execute([':val' => $value]);
                 $valId = $pdo->lastInsertId();
             }
-        $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
+        $pdo->prepare("DELETE FROM $table WHERE book = :book")
+            ->execute([':book' => $bookId]);
+        $stmt = $pdo->prepare("INSERT INTO $table (book, value) VALUES (:book, :val)");
         $stmt->execute([':book' => $bookId, ':val' => $valId]);
         }
     } else {


### PR DESCRIPTION
## Summary
- adjust status update to replace existing row instead of adding new one

## Testing
- `php -l update_status.php`
- `for f in *.php; do php -l $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68821d5bfe0c83299d309eb04f27b3dc