### PR TITLE
Fix missing recommendations column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQLite Books
 
-This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `books_custom_column_10` table so they can be referenced later.
+This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `books_custom_column_10` table so they can be referenced later. If this table is missing from your database it will be created automatically the first time a recommendation is saved.
 
 Each book also has a "Shelf" value stored in the `books_custom_column_11` table. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 


### PR DESCRIPTION
## Summary
- ensure recommendation table exists before storing API output
- document automatic creation of `books_custom_column_10`

## Testing
- `php -l recommend.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_688222119cfc8329abf18ab0be57cb28