### PR TITLE
Add book deletion feature with author cleanup

### DIFF
--- a/delete_book.php
+++ b/delete_book.php
@@ -1,0 +1,38 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
+if ($bookId <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid book id']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $pdo->beginTransaction();
+    $stmt = $pdo->prepare('SELECT author FROM books_authors_link WHERE book = :id');
+    $stmt->execute([':id' => $bookId]);
+    $authorIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+    $delBook = $pdo->prepare('DELETE FROM books WHERE id = :id');
+    $delBook->execute([':id' => $bookId]);
+
+    $check = $pdo->prepare('SELECT COUNT(*) FROM books_authors_link WHERE author = ?');
+    $delAuthor = $pdo->prepare('DELETE FROM authors WHERE id = ?');
+    foreach ($authorIds as $aid) {
+        $check->execute([$aid]);
+        if ((int)$check->fetchColumn() === 0) {
+            $delAuthor->execute([$aid]);
+        }
+    }
+
+    $pdo->commit();
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/list_books.php
+++ b/list_books.php
@@ -430,6 +430,7 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                 </td>
                 <td>
                     <a class="btn btn-sm btn-primary" href="edit_book.php?id=<?= urlencode($book['id']) ?>">View / Edit</a>
+                    <button type="button" class="btn btn-sm btn-danger delete-book ms-1" data-book-id="<?= htmlspecialchars($book['id']) ?>">Delete</button>
                 </td>
             </tr>
             <?php
@@ -719,6 +720,16 @@ $(function() {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: new URLSearchParams({ status: status })
+        }).then(function() { location.reload(); });
+    });
+
+    $(document).on('click', '.delete-book', function() {
+        if (!confirm('Are you sure you want to permanently delete this book?')) return;
+        var bookId = $(this).data('book-id');
+        fetch('delete_book.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ book_id: bookId })
         }).then(function() { location.reload(); });
     });
 


### PR DESCRIPTION
## Summary
- add a Delete button in the book list
- include JS to call new delete_book.php endpoint
- create delete_book.php to remove a book and any orphan authors

## Testing
- `php -l delete_book.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_688225f097d88329a934185e0235058d