### PR TITLE
Add sidebar genre management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project is a small PHP application for browsing and editing an eBook databa
 
 Each book also has a "Shelf" value stored in the `books_custom_column_11` table. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
+Genres are stored in `custom_column_2` and listed in the sidebar. You can add,
+rename or delete genres from that list just like shelves and status values.
+
 ## Searching
 
 Use the search bar at the top of `list_books.php` to search for books by title or author name. A dropdown next to the search field lets you choose between searching the **local** Calibre database or querying the **Open Library** API. Results from Open Library are shown in the same table layout but without local-only actions.

--- a/add_genre.php
+++ b/add_genre.php
@@ -1,0 +1,22 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$genre = trim($_POST['genre'] ?? '');
+if ($genre === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid genre']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS custom_column_2 (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value))");
+    $stmt = $pdo->prepare('INSERT OR IGNORE INTO custom_column_2 (value) VALUES (:val)');
+    $stmt->execute([':val' => $genre]);
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/delete_genre.php
+++ b/delete_genre.php
@@ -1,0 +1,21 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if ($id <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid genre']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare('DELETE FROM custom_column_2 WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/rename_genre.php
+++ b/rename_genre.php
@@ -1,0 +1,36 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$new = trim($_POST['new'] ?? '');
+if ($id <= 0 || $new === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid genre']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare('SELECT id FROM custom_column_2 WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    if ($stmt->fetchColumn() === false) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Genre not found']);
+        exit;
+    }
+    $stmt = $pdo->prepare('SELECT id FROM custom_column_2 WHERE value = :val');
+    $stmt->execute([':val' => $new]);
+    $existingId = $stmt->fetchColumn();
+    if ($existingId === false) {
+        $pdo->prepare('UPDATE custom_column_2 SET value = :val WHERE id = :id')->execute([':val' => $new, ':id' => $id]);
+    } else {
+        $pdo->prepare('UPDATE books_custom_column_2_link SET value = :newid WHERE value = :oldid')->execute([':newid' => $existingId, ':oldid' => $id]);
+        $pdo->prepare('DELETE FROM custom_column_2 WHERE id = :id')->execute([':id' => $id]);
+    }
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- allow adding, renaming and deleting genres from the sidebar
- create supporting PHP endpoints for managing genres
- document sidebar genre functionality

## Testing
- `php -l add_genre.php`
- `php -l delete_genre.php`
- `php -l rename_genre.php`
- `php -l list_books.php`

------
https://chatgpt.com/codex/tasks/task_e_6882295524788329b38e185d760e5e50