### PR TITLE
Add Bootswatch theme selector

### DIFF
--- a/edit_book.php
+++ b/edit_book.php
@@ -29,7 +29,8 @@ if (!$book) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Edit Book</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
 </head>
 <body>
 <?php include "navbar.php"; ?>

--- a/list_books.php
+++ b/list_books.php
@@ -449,7 +449,8 @@ if ($isAjax) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Book List</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js" crossorigin="anonymous"></script>

--- a/navbar.php
+++ b/navbar.php
@@ -72,6 +72,9 @@ $statusNameVal = isset($statusName) ? $statusName : '';
         <li class="nav-item">
           <a class="nav-link" href="reading_challenges.php">Reading Challenge</a>
         </li>
+        <li class="nav-item ms-2">
+          <select id="themeSelect" class="form-select form-select-sm" style="min-width: 10rem;"></select>
+        </li>
       </ul>
     </div>
   </div>

--- a/openlibrary_view.php
+++ b/openlibrary_view.php
@@ -25,7 +25,8 @@ if (!$coverId && !empty($covers)) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?= htmlspecialchars($workTitle) ?></title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
 </head>
 <body>
 <?php include "navbar.php"; ?>

--- a/reading_challenges.php
+++ b/reading_challenges.php
@@ -55,7 +55,8 @@ try {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Reading Challenge</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
 </head>
 <body class="pt-5">
 <?php include "navbar.php"; ?>

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,39 @@
+(function(){
+  const API_URL = 'https://bootswatch.com/api/5.json';
+  const defaultTheme = {
+    name: 'Bootstrap',
+    css: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css'
+  };
+
+  const link = document.getElementById('themeStylesheet');
+  const savedCss = localStorage.getItem('themeCss') || defaultTheme.css;
+  if(link) link.href = savedCss;
+  const select = document.getElementById('themeSelect');
+
+  function populate(themes){
+    if(!select) return;
+    select.innerHTML = '';
+    themes.forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t.css;
+      opt.textContent = t.name;
+      select.appendChild(opt);
+    });
+    select.value = savedCss;
+    select.addEventListener('change', () => {
+      const css = select.value;
+      if(link) link.href = css;
+      localStorage.setItem('themeCss', css);
+    });
+  }
+
+  fetch(API_URL)
+    .then(r => r.json())
+    .then(data => {
+      const themes = data.themes.map(t => ({name: t.name, css: t.cssCdn}));
+      populate([defaultTheme, ...themes]);
+    })
+    .catch(() => {
+      populate([defaultTheme]);
+    });
+})();

--- a/view_book.php
+++ b/view_book.php
@@ -59,7 +59,8 @@ try {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?= htmlspecialchars($book['title']) ?></title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
 </head>
 <body class="pt-5">
 <?php include "navbar.php"; ?>


### PR DESCRIPTION
## Summary
- fetch list of Bootswatch themes from the public API
- add a theme dropdown to the navbar
- load the chosen theme on every page via `theme.js`

## Testing
- `php -l navbar.php`
- `php -l edit_book.php`
- `php -l list_books.php`
- `php -l openlibrary_view.php`
- `php -l reading_challenges.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_68822af32c588329a9cfc451ebd1b78e