### PR TITLE
Add Anna's Archive search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ rename or delete genres from that list just like shelves and status values.
 
 ## Searching
 
-Use the search bar at the top of `list_books.php` to search for books by title or author name. A dropdown next to the search field lets you choose between searching the **local** Calibre database or querying the **Open Library** API. Results from Open Library are shown in the same table layout but without local-only actions.
+Use the search bar at the top of `list_books.php` to search for books by title or author name. A dropdown next to the search field lets you choose between searching the **local** Calibre database, querying the **Open Library** API, or searching **Anna's Archive**. Results from external sources are shown in the same table layout but without local-only actions.
 
 When viewing a book you can click **Get Book Recommendations**. The returned text is parsed to identify
 the recommended title and author. Each title links back to `list_books.php` with an Open Library search
 so you can quickly explore more details about that book.
 
 To enable the recommendation feature, set the `OPENROUTER_API_KEY` environment variable with your API key. The `recommend.php` endpoint calls `get_book_recommendations()` defined in `book_recommend.php` to contact the API and return results.
+To enable searching Anna's Archive, set the `ANNA_API_KEY` environment variable. The search dropdown will query the Anna's Archive API when this option is selected.

--- a/annas_archive.php
+++ b/annas_archive.php
@@ -1,0 +1,39 @@
+<?php
+function search_annas_archive(string $query): array {
+    $apiKey = getenv('ANNA_API_KEY');
+    if (!$apiKey) {
+        return [];
+    }
+
+    $url = 'https://annas-archive-api.p.rapidapi.com/search?q=' . urlencode($query) . '&skip=0&limit=20&source=libgenLi,libgenRs,zLibrary,sciHub';
+
+    $curl = curl_init();
+    curl_setopt_array($curl, [
+        CURLOPT_URL => $url,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_ENCODING => '',
+        CURLOPT_MAXREDIRS => 10,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+        CURLOPT_CUSTOMREQUEST => 'GET',
+        CURLOPT_HTTPHEADER => [
+            'x-rapidapi-host: annas-archive-api.p.rapidapi.com',
+            'x-rapidapi-key: ' . $apiKey
+        ],
+    ]);
+
+    $response = curl_exec($curl);
+    if ($response === false) {
+        curl_close($curl);
+        return [];
+    }
+    curl_close($curl);
+
+    $data = json_decode($response, true);
+    if (!is_array($data) || !isset($data['books']) || !is_array($data['books'])) {
+        return [];
+    }
+
+    return $data['books'];
+}
+?>

--- a/list_books.php
+++ b/list_books.php
@@ -200,6 +200,11 @@ if ($source === 'openlibrary' && $search !== '') {
     $books = search_openlibrary($search);
     $totalBooks = count($books);
     $totalPages = 1;
+} elseif ($source === 'annas' && $search !== '') {
+    require_once 'annas_archive.php';
+    $books = search_annas_archive($search);
+    $totalBooks = count($books);
+    $totalPages = 1;
 } else {
     try {
         $totalSql = "SELECT COUNT(*) FROM books b $where";
@@ -341,6 +346,31 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                         &mdash;
                     <?php endif; ?>
                 </td>
+                <td>&mdash;</td>
+                <td>&mdash;</td>
+                <td>&mdash;</td>
+            </tr>
+            <?php
+        } elseif ($source === 'annas') {
+            ?>
+            <tr>
+                <td>
+                    <?php if (!empty($book['imgUrl'])): ?>
+                        <img src="<?= htmlspecialchars($book['imgUrl']) ?>" alt="Cover" class="img-thumbnail" style="width: 150px; height: auto;">
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                </td>
+                <td>
+                    <?php if (!empty($book['md5'])): ?>
+                        <a href="https://annas-archive.org/md5/<?= urlencode($book['md5']) ?>" target="_blank">
+                            <?= htmlspecialchars($book['title']) ?>
+                        </a>
+                    <?php else: ?>
+                        <?= htmlspecialchars($book['title']) ?>
+                    <?php endif; ?>
+                </td>
+                <td><?= $book['author'] !== '' ? htmlspecialchars($book['author']) : '&mdash;' ?></td>
                 <td>&mdash;</td>
                 <td>&mdash;</td>
                 <td>&mdash;</td>

--- a/navbar.php
+++ b/navbar.php
@@ -37,6 +37,7 @@ $statusNameVal = isset($statusName) ? $statusName : '';
         <select name="source" class="form-select me-2" style="max-width: 12rem;">
           <option value="local"<?= $sourceVal === 'local' ? ' selected' : '' ?>>Local</option>
           <option value="openlibrary"<?= $sourceVal === 'openlibrary' ? ' selected' : '' ?>>Open Library</option>
+          <option value="annas"<?= $sourceVal === 'annas' ? ' selected' : '' ?>>Anna's Archive</option>
         </select>
         <button class="btn btn-outline-secondary" type="submit">Search</button>
       </form>


### PR DESCRIPTION
## Summary
- support searching Anna's Archive via its API
- show Anna's Archive results in book list
- expose new dropdown option in navbar
- document Anna's Archive search and API key env var

## Testing
- `php -l annas_archive.php`
- `php -l list_books.php`
- `php -l navbar.php`

------
https://chatgpt.com/codex/tasks/task_e_6882372af8f88329a3850a113d4680c7