### PR TITLE
Fix missing Anna's Archive download button

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -379,7 +379,13 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                 <td><?= $book['author'] !== '' ? htmlspecialchars($book['author']) : '&mdash;' ?></td>
                 <td>&mdash;</td>
                 <td>&mdash;</td>
-                <td>&mdash;</td>
+                <td>
+                    <?php if (!empty($book['md5'])): ?>
+                        <button type="button" class="btn btn-sm btn-success annas-download" data-md5="<?= htmlspecialchars($book['md5']) ?>">Download</button>
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                </td>
             </tr>
             <?php
         } else {


### PR DESCRIPTION
## Summary
- render Anna's Archive search results with a direct download button

## Testing
- `php -l list_books.php`
- `php -l annas_archive.php annas_download.php`

------
https://chatgpt.com/codex/tasks/task_e_68823cc16d5c8329a3e22a55f45016ba