### PR TITLE
Add automatic custom column initialization

### DIFF
--- a/db.php
+++ b/db.php
@@ -20,6 +20,7 @@ function getDatabaseConnection($path = 'metadata.old.db') {
             return $title;
         }, 1);
 
+
         // Provide a uuid4() function used by triggers in the Calibre schema.
         // Generates a version 4 UUID string in the standard 8-4-4-4-12 format.
         $pdo->sqliteCreateFunction('uuid4', function () {
@@ -29,9 +30,43 @@ function getDatabaseConnection($path = 'metadata.old.db') {
             return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
         }, 0);
 
+        initializeCustomColumns($pdo);
+
         return $pdo;
     } catch (PDOException $e) {
         die('Connection failed: ' . $e->getMessage());
+    }
+}
+
+function initializeCustomColumns(PDO $pdo): void {
+    // Ensure shelves table and default entries
+    try {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
+        foreach (['Physical','Ebook Calibre','PDFs'] as $def) {
+            $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$def]);
+        }
+
+        // Shelf assignment column
+        $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_11 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+        $pdo->exec("INSERT INTO books_custom_column_11 (book, value)\n                SELECT id, 'Ebook Calibre' FROM books\n                WHERE id NOT IN (SELECT book FROM books_custom_column_11)");
+
+        // Recommendation storage column
+        $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_10 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+
+        // Reading status column metadata
+        $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+        $stmt->execute();
+        $statusId = $stmt->fetchColumn();
+        if ($statusId === false) {
+            $statusId = (int)$pdo->query("SELECT COALESCE(MAX(id),0)+1 FROM custom_columns")->fetchColumn();
+            $insert = $pdo->prepare("INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES (:id, 'status', 'status', 'text', 0, 1, 0, 1, '{}')");
+            $insert->execute([':id' => $statusId]);
+        }
+        $statusTable = 'books_custom_column_' . (int)$statusId;
+        $pdo->exec("CREATE TABLE IF NOT EXISTS $statusTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+        $pdo->exec("INSERT INTO $statusTable (book, value)\n                SELECT id, 'Want to Read' FROM books\n                WHERE id NOT IN (SELECT book FROM $statusTable)");
+    } catch (PDOException $e) {
+        // Ignore initialization errors to avoid blocking the application
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- ensure required tables and custom columns exist when connecting to the DB

## Testing
- `ls *.php | xargs -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688254321be083299daf34ca2f3c96c8