### PR TITLE
Add Open Library metadata button

### DIFF
--- a/openlibrary.php
+++ b/openlibrary.php
@@ -24,7 +24,8 @@ function search_openlibrary(string $query): array {
             'title' => $doc['title'] ?? '',
             'authors' => isset($doc['author_name']) ? implode(', ', (array)$doc['author_name']) : '',
             'cover_id' => $doc['cover_i'] ?? null,
-            'key' => $doc['key'] ?? ''
+            'key' => $doc['key'] ?? '',
+            'year' => $doc['first_publish_year'] ?? null
         ];
     }
     return $results;

--- a/openlibrary_search.php
+++ b/openlibrary_search.php
@@ -1,0 +1,12 @@
+<?php
+header('Content-Type: application/json');
+require_once 'openlibrary.php';
+
+$q = trim($_GET['q'] ?? '');
+if ($q === '') {
+    echo json_encode(['books' => []]);
+    exit;
+}
+
+$books = search_openlibrary($q);
+echo json_encode(['books' => $books]);


### PR DESCRIPTION
## Summary
- extend Open Library search results with publication year
- add endpoint to query Open Library
- add an "Open Library" metadata button to book view page
- implement modal and JS handlers for updating metadata from Open Library

## Testing
- `php -l openlibrary_search.php`
- `php -l openlibrary.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_68826d2afce08329b1344ec2b942a658