### PR TITLE
Add selectable Calibre DB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Each book also has a "Shelf" value stored in the `books_custom_column_11` table.
 Genres are stored in `custom_column_2` and listed in the sidebar. You can add,
 rename or delete genres from that list just like shelves and status values.
 
+## Preferences
+
+Open `preferences.php` to set the path to your Calibre `metadata.db` file. The
+chosen path is stored in the session so different users can work with separate
+databases. You can also choose to save the path for all users which updates the
+`preferences.json` file used as the global default.
+
 ## Adding Your Own Books
 
 Use `add_physical_book.php` to upload an eBook file directly through the web

--- a/add_book_physical.php
+++ b/add_book_physical.php
@@ -16,40 +16,16 @@ $authors_str = $argv[2];
 $file_path = $argv[3];
 $tags_str = $argc > 4 ? $argv[4] : "";
 
-$libraryPath = "/home/david/nilla";  // Adjust this to your Calibre library path
-$dbPath = $libraryPath . "./metadata.old.db";
+require_once 'db.php';
+$libraryPath = getLibraryPath();
+$dbPath = currentDatabasePath();
 
 if (!file_exists($dbPath)) {
     die("Error: metadata.db not found at $dbPath\n");
 }
 
 // --- Database Setup ---
-$pdo = new PDO("sqlite:$dbPath");
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-// Register Calibre-like functions
-$pdo->sqliteCreateFunction('title_sort', function ($title) {
-    $title = trim($title ?? '');
-    if ($title === '') return '';
-    if (preg_match('/^(a|an|the)\s+(.+)/i', $title, $m)) {
-        return $m[2] . ', ' . ucfirst(strtolower($m[1]));
-    }
-    return $title;
-}, 1);
-
-$pdo->sqliteCreateFunction('author_sort', function ($author) {
-    $author = trim($author ?? '');
-    if ($author === '') return '';
-    $parts = explode(' ', $author);
-    return count($parts) > 1 ? array_pop($parts) . ', ' . implode(' ', $parts) : $author;
-}, 1);
-
-$pdo->sqliteCreateFunction('uuid4', function () {
-    $data = random_bytes(16);
-    $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
-    $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
-    return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
-}, 0);
+$pdo = getDatabaseConnection($dbPath);
 
 // --- Helper Functions ---
 function safe_filename($name, $max_length = 150) {

--- a/add_col.sh
+++ b/add_col.sh
@@ -1,5 +1,6 @@
-!/bin/bash
-DB="metadata.old.db"
+#!/bin/bash
+# Determine DB path from PHP preferences
+DB=$(php -r "require 'db.php'; echo currentDatabasePath();")
 
 # Get the next custom column ID
 NEXT_ID=$(sqlite3 "$DB" "SELECT COALESCE(MAX(id), 0) + 1 FROM custom_columns;")

--- a/import.py
+++ b/import.py
@@ -2,6 +2,7 @@ import csv
 import os
 import sqlite3
 import uuid
+import json
 from datetime import datetime
 
 # === CONFIGURATION ===
@@ -44,7 +45,18 @@ def uuid4_sqlite() -> str:
     return str(uuid.uuid4())
 
 # === MAIN SCRIPT ===
-db_path = os.path.join(LIBRARY_PATH, "metadata.db")
+prefs_file = os.path.join(os.path.dirname(__file__), "preferences.json")
+db_path = None
+if os.path.exists(prefs_file):
+    try:
+        with open(prefs_file, "r", encoding="utf-8") as f:
+            db_path = json.load(f).get("db_path")
+    except Exception:
+        db_path = None
+if not db_path:
+    db_path = os.path.join(LIBRARY_PATH, "metadata.db")
+else:
+    LIBRARY_PATH = os.path.dirname(db_path)
 print(f"Using Calibre DB: {db_path}")
 
 conn = sqlite3.connect(db_path)

--- a/navbar.php
+++ b/navbar.php
@@ -73,6 +73,9 @@ $statusNameVal = isset($statusName) ? $statusName : '';
         <li class="nav-item">
           <a class="nav-link" href="reading_challenges.php">Reading Challenge</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="preferences.php">Preferences</a>
+        </li>
         <li class="nav-item ms-2">
           <select id="themeSelect" class="form-select form-select-sm" style="min-width: 10rem;"></select>
         </li>

--- a/preferences.json
+++ b/preferences.json
@@ -1,0 +1,3 @@
+{
+    "db_path": "metadata.old.db"
+}

--- a/preferences.php
+++ b/preferences.php
@@ -1,0 +1,44 @@
+<?php
+require_once 'db.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $newPath = trim($_POST['db_path'] ?? '');
+    if ($newPath !== '') {
+        $_SESSION['db_path'] = $newPath;
+        if (isset($_POST['save_global'])) {
+            setPreference('db_path', $newPath);
+        }
+        $message = 'Preferences saved.';
+    }
+}
+
+$currentPath = currentDatabasePath();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Preferences</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-4">
+  <h1 class="mb-4">Preferences</h1>
+  <?php if ($message): ?>
+    <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
+  <?php endif; ?>
+  <form method="post">
+    <div class="mb-3">
+      <label for="db_path" class="form-label">Calibre database path</label>
+      <input type="text" id="db_path" name="db_path" class="form-control" value="<?php echo htmlspecialchars($currentPath); ?>">
+    </div>
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" value="1" id="save_global" name="save_global">
+      <label class="form-check-label" for="save_global">
+        Save as default for all users
+      </label>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add PHP preferences page
- store database path in `preferences.json`
- load preferences in db helpers
- update CLI scripts and shell script
- link to Preferences from navbar
- document the new feature

## Testing
- `php -l db.php`
- `php -l add_book_physical.php`
- `php -l preferences.php`
- `python3 -m py_compile import.py`
- `shellcheck add_col.sh`

------
https://chatgpt.com/codex/tasks/task_e_6882b1ad7144832993270d8a78f5a0c6