### PR TITLE
Make Calibre library path configurable

### DIFF
--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -7,10 +7,7 @@ function safe_filename(string $name, int $max_length = 150): string {
 }
 
 $pdo = getDatabaseConnection();
-$libraryPath = realpath(__DIR__ . '/ebooks');
-if ($libraryPath === false) {
-    $libraryPath = __DIR__ . '/ebooks';
-}
+$libraryPath = currentLibraryPath();
 
 $message = '';
 $errors = [];

--- a/db.php
+++ b/db.php
@@ -37,8 +37,19 @@ function currentDatabasePath(): string {
     return getPreference('db_path', 'metadata.old.db');
 }
 
+function currentLibraryPath(): string {
+    if (!empty($_SESSION['library_path'])) {
+        return rtrim($_SESSION['library_path'], '/');
+    }
+    $pref = getPreference('library_path');
+    if ($pref !== null && $pref !== '') {
+        return rtrim($pref, '/');
+    }
+    return __DIR__ . '/ebooks';
+}
+
 function getLibraryPath(): string {
-    return dirname(currentDatabasePath());
+    return currentLibraryPath();
 }
 
 function getDatabaseConnection(?string $path = null) {

--- a/list_books.php
+++ b/list_books.php
@@ -2,6 +2,7 @@
 require_once 'db.php';
 
 $pdo = getDatabaseConnection();
+$libraryUrl = rtrim(currentLibraryPath(), '/');
 
 // Ensure shelf table and custom column exist
 try {
@@ -403,7 +404,7 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                 <td>
                     <?php if (!empty($book['has_cover'])): ?>
                         <a href="view_book.php?id=<?= urlencode($book['id']) ?>">
-                            <img src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" alt="Cover" class="img-thumbnail" style="width: 150px; height: auto;">
+                            <img src="<?= htmlspecialchars($libraryUrl . '/' . $book['path'] . '/cover.jpg') ?>" alt="Cover" class="img-thumbnail" style="width: 150px; height: auto;">
                         </a>
                     <?php else: ?>
                         &mdash;

--- a/preferences.json
+++ b/preferences.json
@@ -1,3 +1,4 @@
 {
-    "db_path": "metadata.old.db"
+    "db_path": "metadata.old.db",
+    "library_path": "ebooks"
 }

--- a/preferences.php
+++ b/preferences.php
@@ -3,28 +3,53 @@ require_once 'db.php';
 
 $message = '';
 $alertClass = 'success';
+$currentPath = currentDatabasePath();
+$currentLibrary = currentLibraryPath();
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $newPath = trim($_POST['db_path'] ?? '');
+    $newLib = trim($_POST['lib_path'] ?? '');
     if ($newPath !== '') {
         $_SESSION['db_path'] = $newPath;
         if (isset($_POST['save_global'])) {
             setPreference('db_path', $newPath);
         }
+    }
+    if ($newLib !== '') {
+        $_SESSION['library_path'] = $newLib;
+        if (isset($_POST['save_global'])) {
+            setPreference('library_path', $newLib);
+        }
+    }
 
-        $writable = file_exists($newPath)
+    $dbWritable = true;
+    if ($newPath !== '') {
+        $dbWritable = file_exists($newPath)
             ? is_writable($newPath)
             : (is_dir(dirname($newPath)) && is_writable(dirname($newPath)));
+    }
+    $libWritable = true;
+    if ($newLib !== '') {
+        $libWritable = is_dir($newLib)
+            ? is_writable($newLib)
+            : (is_dir(dirname($newLib)) && is_writable(dirname($newLib)));
+    }
 
-        if ($writable) {
-            $message = 'Preferences saved.';
-        } else {
+    if ($dbWritable && $libWritable) {
+        $message = 'Preferences saved.';
+        $currentPath = $newPath !== '' ? $newPath : $currentPath;
+        $currentLibrary = $newLib !== '' ? $newLib : $currentLibrary;
+    } else {
+        $alertClass = 'danger';
+        if (!$dbWritable && !$libWritable) {
+            $message = 'Database and library paths are not writable.';
+        } elseif (!$dbWritable) {
             $message = 'Database path is not writable.';
-            $alertClass = 'danger';
+        } else {
+            $message = 'Library path is not writable.';
         }
     }
 }
-
-$currentPath = currentDatabasePath();
 ?>
 <!doctype html>
 <html lang="en">
@@ -42,6 +67,10 @@ $currentPath = currentDatabasePath();
     <div class="mb-3">
       <label for="db_path" class="form-label">Calibre database path</label>
       <input type="text" id="db_path" name="db_path" class="form-control" value="<?php echo htmlspecialchars($currentPath); ?>">
+    </div>
+    <div class="mb-3">
+      <label for="lib_path" class="form-label">Calibre library path</label>
+      <input type="text" id="lib_path" name="lib_path" class="form-control" value="<?php echo htmlspecialchars($currentLibrary); ?>">
     </div>
     <div class="form-check mb-3">
       <input class="form-check-input" type="checkbox" value="1" id="save_global" name="save_global">

--- a/reading_challenges.php
+++ b/reading_challenges.php
@@ -2,6 +2,7 @@
 require_once 'db.php';
 
 $pdo = getDatabaseConnection();
+$libraryUrl = rtrim(currentLibraryPath(), '/');
 
 $year = (int)date('Y');
 $message = '';
@@ -105,7 +106,7 @@ try {
                     <td>
                         <?php if (!empty($b['has_cover'])): ?>
                             <a href="view_book.php?id=<?= urlencode($b['id']) ?>">
-                                <img src="ebooks/<?= htmlspecialchars($b['path']) ?>/cover.jpg" alt="Cover" class="img-thumbnail" style="width: 80px; height: auto;">
+                                <img src="<?= htmlspecialchars($libraryUrl . '/' . $b['path'] . '/cover.jpg') ?>" alt="Cover" class="img-thumbnail" style="width: 80px; height: auto;">
                             </a>
                         <?php else: ?>
                             &mdash;

--- a/update_metadata.php
+++ b/update_metadata.php
@@ -26,10 +26,7 @@ try {
         $pathStmt->execute([':id' => $bookId]);
         $bookPath = $pathStmt->fetchColumn();
         if ($bookPath !== false) {
-            $libraryPath = realpath(__DIR__ . '/ebooks');
-            if ($libraryPath === false) {
-                $libraryPath = __DIR__ . '/ebooks';
-            }
+            $libraryPath = currentLibraryPath();
             $data = @file_get_contents($imgUrl);
             if ($data !== false) {
                 $coverFile = $libraryPath . '/' . $bookPath . '/cover.jpg';

--- a/view_book.php
+++ b/view_book.php
@@ -2,6 +2,7 @@
 require_once 'db.php';
 
 $pdo = getDatabaseConnection();
+$libraryUrl = rtrim(currentLibraryPath(), '/');
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($id <= 0) {
@@ -96,7 +97,7 @@ try {
     <div class="row mb-4">
         <div class="col-md-3">
             <?php if (!empty($book['has_cover'])): ?>
-                <img src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" alt="Cover" class="img-fluid">
+                <img src="<?= htmlspecialchars($libraryUrl . '/' . $book['path'] . '/cover.jpg') ?>" alt="Cover" class="img-fluid">
             <?php else: ?>
                 <div class="text-muted">No cover</div>
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- add `currentLibraryPath()` and update utilities to use it
- update add_physical_book and update_metadata to use the configured library
- show correct library path for cover images across the app
- extend preferences page with a field for library path and writeability checks
- store default library path in `preferences.json`

## Testing
- `php -l db.php && php -l add_physical_book.php && php -l update_metadata.php && php -l list_books.php && php -l reading_challenges.php && php -l view_book.php && php -l preferences.php`

------
https://chatgpt.com/codex/tasks/task_e_6882beedadc88329846dd1f517e20b5a