### PR TITLE
Introduce cookie-based login and per-user preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ rename or delete genres from that list just like shelves and status values.
 
 ## Preferences
 
-Open `preferences.php` to set the path to your Calibre `metadata.db` file. The
-chosen path is stored in the session so different users can work with separate
-databases. You can also choose to save the path for all users which updates the
-`preferences.json` file used as the global default.
+Visit `login.php` to sign in. User accounts and their preferences are stored in
+`users.json`. After logging in you can open `preferences.php` to set the path to
+your Calibre `metadata.db` file. Preferences are saved per user without using
+PHP sessions. You can still choose to save the path globally for all users which
+updates the `preferences.json` file.
 
 ## Adding Your Own Books
 

--- a/add_book.php
+++ b/add_book.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $title = trim($_POST['title'] ?? '');
 $authors = trim($_POST['authors'] ?? '');

--- a/add_genre.php
+++ b/add_genre.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $genre = trim($_POST['genre'] ?? '');
 if ($genre === '') {

--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+requireLogin();
 
 function safe_filename(string $name, int $max_length = 150): string {
     $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);

--- a/add_shelf.php
+++ b/add_shelf.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $shelf = trim($_POST['shelf'] ?? '');
 if ($shelf === '') {

--- a/add_status.php
+++ b/add_status.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $status = trim($_POST['status'] ?? '');
 if ($status === '') {

--- a/author_autocomplete.php
+++ b/author_autocomplete.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+requireLogin();
 header('Content-Type: application/json');
 
 $term = isset($_GET['term']) ? trim((string)$_GET['term']) : '';

--- a/delete_book.php
+++ b/delete_book.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
 if ($bookId <= 0) {

--- a/delete_genre.php
+++ b/delete_genre.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 if ($id <= 0) {

--- a/delete_shelf.php
+++ b/delete_shelf.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $shelf = trim($_POST['shelf'] ?? '');
 if ($shelf === '') {

--- a/delete_status.php
+++ b/delete_status.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $status = trim($_POST['status'] ?? '');
 if ($status === '') {

--- a/edit_book.php
+++ b/edit_book.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+requireLogin();
 
 $pdo = getDatabaseConnection();
 

--- a/list_books.php
+++ b/list_books.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+requireLogin();
 
 $pdo = getDatabaseConnection();
 

--- a/login.php
+++ b/login.php
@@ -1,0 +1,40 @@
+<?php
+require_once 'db.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+    if (validateUser($username, $password)) {
+        setcookie('user', $username, time() + 60 * 60 * 24 * 30);
+        header('Location: list_books.php');
+        exit;
+    }
+    $error = 'Invalid credentials';
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-4">
+  <h1 class="mb-4">Login</h1>
+  <?php if ($error): ?>
+    <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+  <?php endif; ?>
+  <form method="post">
+    <div class="mb-3">
+      <label for="username" class="form-label">Username</label>
+      <input type="text" id="username" name="username" class="form-control">
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Password</label>
+      <input type="password" id="password" name="password" class="form-control">
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+  </form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,4 @@
+<?php
+setcookie('user', '', time() - 3600);
+header('Location: login.php');
+exit;

--- a/navbar.php
+++ b/navbar.php
@@ -76,6 +76,16 @@ $statusNameVal = isset($statusName) ? $statusName : '';
         <li class="nav-item ms-2">
           <select id="themeSelect" class="form-select form-select-sm" style="min-width: 10rem;"></select>
         </li>
+        <?php if (currentUser()): ?>
+        <li class="nav-item ms-3">
+          <span class="navbar-text me-2"><?= htmlspecialchars(currentUser()) ?></span>
+          <a class="btn btn-sm btn-outline-light" href="logout.php">Logout</a>
+        </li>
+        <?php else: ?>
+        <li class="nav-item ms-3">
+          <a class="btn btn-sm btn-outline-light" href="login.php">Login</a>
+        </li>
+        <?php endif; ?>
       </ul>
     </div>
   </div>

--- a/preferences.php
+++ b/preferences.php
@@ -1,12 +1,13 @@
 <?php
 require_once 'db.php';
+requireLogin();
 
 $message = '';
 $alertClass = 'success';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $newPath = trim($_POST['db_path'] ?? '');
     if ($newPath !== '') {
-        $_SESSION['db_path'] = $newPath;
+        setUserPreference(currentUser(), 'db_path', $newPath);
         if (isset($_POST['save_global'])) {
             setPreference('db_path', $newPath);
         }

--- a/reading_challenges.php
+++ b/reading_challenges.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+requireLogin();
 
 $pdo = getDatabaseConnection();
 

--- a/recommend.php
+++ b/recommend.php
@@ -3,6 +3,7 @@ header('Content-Type: application/json');
 
 require_once 'book_recommend.php';
 require_once 'db.php';
+requireLogin();
 
 $authors = $_GET['authors'] ?? '';
 $title = $_GET['title'] ?? '';

--- a/rename_genre.php
+++ b/rename_genre.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 $new = trim($_POST['new'] ?? '');

--- a/rename_shelf.php
+++ b/rename_shelf.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $old = trim($_POST['shelf'] ?? '');
 $new = trim($_POST['new'] ?? '');

--- a/rename_status.php
+++ b/rename_status.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $old = trim($_POST['status'] ?? '');
 $new = trim($_POST['new'] ?? '');

--- a/update_metadata.php
+++ b/update_metadata.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 require_once 'annas_archive.php';
 
 $bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;

--- a/update_shelf.php
+++ b/update_shelf.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
 $value = $_POST['value'] ?? '';

--- a/update_status.php
+++ b/update_status.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
 $value = trim($_POST['value'] ?? '');

--- a/update_title.php
+++ b/update_title.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+requireLogin();
 
 $bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
 $title = trim($_POST['title'] ?? '');

--- a/users.json
+++ b/users.json
@@ -1,0 +1,8 @@
+{
+    "admin": {
+        "password": "admin",
+        "prefs": {
+            "db_path": "metadata.old.db"
+        }
+    }
+}

--- a/view_book.php
+++ b/view_book.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'db.php';
+requireLogin();
 
 $pdo = getDatabaseConnection();
 


### PR DESCRIPTION
## Summary
- add simple cookie login pages
- store per-user preferences in `users.json`
- update DB helper with user management helpers
- require login for all app pages
- update navigation with login/logout links
- document login system in README

## Testing
- `php -l login.php`
- `php -l logout.php`
- `php -l db.php`
- `php -l preferences.php`
- `php -l navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_68837821994883299e355a94125c7447