### PR TITLE
Fix detection of missing ebook files

### DIFF
--- a/db.php
+++ b/db.php
@@ -107,9 +107,11 @@ function bookHasFile(string $relativePath): bool {
         return false;
     }
     foreach (glob($dir . '/*') as $file) {
-        if (!is_file($file)) continue;
+        if (!is_file($file)) {
+            continue;
+        }
         $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
-        if (!in_array($ext, ['epub', 'mobi', 'azw3', 'txt'])) {
+        if (in_array($ext, ['epub', 'mobi', 'azw3', 'txt'])) {
             return true;
         }
     }


### PR DESCRIPTION
## Summary
- correct `bookHasFile` logic to detect actual ebook files

## Testing
- `php -l db.php`
- `grep -l "<?php" -R | grep -v vendor | xargs -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68839f3f7f7483298bc42d0e3c4ba84f