### PR TITLE
Add AI synopsis feature

### DIFF
--- a/book_synopsis.php
+++ b/book_synopsis.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Generate a short synopsis for a book using OpenRouter.
+ *
+ * Set the environment variable OPENROUTER_API_KEY with your API key.
+ */
+function get_book_synopsis(string $title, string $authors): string {
+    $apiKey = getenv('OPENROUTER_API_KEY') ?: 'your_api_key_here';
+
+    $payload = [
+        'model' => 'anthropic/claude-sonnet-4',
+        'messages' => [
+            [
+                'role' => 'system',
+                'content' => 'You are a helpful assistant that writes concise book synopses.'
+            ],
+            [
+                'role' => 'user',
+                'content' => "Give me a one paragraph synopsis of '{$title}' by {$authors}."
+            ]
+        ],
+        'temperature' => 0.7,
+        'max_tokens' => 300
+    ];
+
+    $ch = curl_init('https://openrouter.ai/api/v1/chat/completions');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "Authorization: Bearer {$apiKey}",
+        'Content-Type: application/json'
+    ]);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $error = curl_error($ch);
+        curl_close($ch);
+        throw new Exception('Curl error: ' . $error);
+    }
+
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($status >= 400) {
+        throw new Exception('API request failed with status ' . $status . ': ' . $response);
+    }
+
+    $data = json_decode($response, true);
+    if (!isset($data['choices'][0]['message']['content'])) {
+        throw new Exception('Invalid API response');
+    }
+
+    return trim($data['choices'][0]['message']['content']);
+}
+?>

--- a/synopsis.php
+++ b/synopsis.php
@@ -1,0 +1,31 @@
+<?php
+header('Content-Type: application/json');
+
+require_once 'book_synopsis.php';
+require_once 'db.php';
+requireLogin();
+
+$title = $_GET['title'] ?? '';
+$authors = $_GET['authors'] ?? '';
+$bookId = isset($_GET['book_id']) ? (int)$_GET['book_id'] : 0;
+
+if ($title === '' || $bookId <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing parameters']);
+    exit;
+}
+
+try {
+    $output = get_book_synopsis($title, $authors);
+
+    $pdo = getDatabaseConnection();
+    $stmt = $pdo->prepare('INSERT INTO comments (book, text) VALUES (:book, :text) '
+        . 'ON CONFLICT(book) DO UPDATE SET text=excluded.text');
+    $stmt->execute([':book' => $bookId, ':text' => $output]);
+
+    echo json_encode(['output' => $output]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- add `book_synopsis.php` with helper to call OpenRouter and get a synopsis
- add `synopsis.php` endpoint to store the generated synopsis in the database
- show new **Generate Synopsis** button on book view page
- display saved synopsis and update it after calling the API

## Testing
- `php -l book_synopsis.php`
- `php -l synopsis.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_6883a1b52d8c8329a36d32da851f3b12