### PR TITLE
Split remote book search pages

### DIFF
--- a/annas_results.php
+++ b/annas_results.php
@@ -1,0 +1,122 @@
+<?php
+require_once 'db.php';
+requireLogin();
+require_once 'annas_archive.php';
+
+$search = isset($_GET['search']) ? trim((string)$_GET['search']) : '';
+$sort = $_GET['sort'] ?? 'author_series';
+$source = 'annas';
+$books = [];
+if ($search !== '') {
+    $books = search_annas_archive($search);
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Anna's Archive Results</title>
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
+</head>
+<body class="pt-5">
+<?php include "navbar.php"; ?>
+<div class="container my-4">
+    <h1 class="mb-4">Anna's Archive Results</h1>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Cover</th>
+                <th class="title-col">Title</th>
+                <th>Author(s)</th>
+                <th>Genre</th>
+                <th>Year</th>
+                <th>Size</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($books as $book): ?>
+            <tr>
+                <td>
+                    <?php if (!empty($book['imgUrl'])): ?>
+                        <img src="<?= htmlspecialchars($book['imgUrl']) ?>" alt="Cover" class="img-thumbnail" style="width: 150px; height: auto;">
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                </td>
+                <td class="title-col">
+                    <?php if (!empty($book['md5'])): ?>
+                        <a href="https://annas-archive.org/md5/<?= urlencode($book['md5']) ?>" target="_blank">
+                            <?= htmlspecialchars($book['title']) ?>
+                        </a>
+                    <?php else: ?>
+                        <?= htmlspecialchars($book['title']) ?>
+                    <?php endif; ?>
+                </td>
+                <td><?= $book['author'] !== '' ? htmlspecialchars($book['author']) : '&mdash;' ?></td>
+                <td><?= $book['genre'] !== '' ? htmlspecialchars($book['genre']) : '&mdash;' ?></td>
+                <td><?= $book['year'] !== '' ? htmlspecialchars($book['year']) : '&mdash;' ?></td>
+                <td><?= $book['size'] !== '' ? htmlspecialchars($book['size']) : '&mdash;' ?></td>
+                <td>
+                    <?php if (!empty($book['md5'])): ?>
+                        <button type="button" class="btn btn-sm btn-success annas-download" data-md5="<?= htmlspecialchars($book['md5']) ?>">
+                            Download<?php if (!empty($book['format'])): ?> <?= htmlspecialchars(strtoupper($book['format'])) ?><?php endif; ?>
+                        </button>
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                    <button type="button" class="btn btn-sm btn-primary ms-1 annas-add"
+                            data-title="<?= htmlspecialchars($book['title'], ENT_QUOTES) ?>"
+                            data-authors="<?= htmlspecialchars($book['author'], ENT_QUOTES) ?>">
+                        Add to Library
+                    </button>
+                    <span class="annas-add-result ms-1"></span>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+$(document).on('click', '.annas-download', function() {
+    var md5 = $(this).data('md5');
+    if (!md5) return;
+    fetch('annas_download.php?md5=' + encodeURIComponent(md5))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            var url = data.url || (data.mirrors && data.mirrors[0]) || (Array.isArray(data) ? data[0] : null);
+            if (url) {
+                window.open(url, '_blank');
+            } else {
+                alert('Download link unavailable');
+            }
+        })
+        .catch(function() { alert('Download failed'); });
+});
+$(document).on('click', '.annas-add', function() {
+    var title = $(this).data('title');
+    var authors = $(this).data('authors');
+    var $result = $(this).siblings('.annas-add-result');
+    $result.text('Adding...');
+    fetch('add_book.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ title: title, authors: authors })
+    }).then(function(r) { return r.json(); })
+    .then(function(data) {
+        if (data.status === 'ok') {
+            $result.text('Book added');
+        } else {
+            $result.text(data.error || 'Error adding');
+        }
+    }).catch(function() {
+        $result.text('Error adding');
+    });
+});
+</script>
+</body>
+</html>

--- a/google_results.php
+++ b/google_results.php
@@ -1,0 +1,54 @@
+<?php
+require_once 'db.php';
+requireLogin();
+require_once 'google_books.php';
+
+$search = isset($_GET['search']) ? trim((string)$_GET['search']) : '';
+$sort = $_GET['sort'] ?? 'author_series';
+$source = 'google';
+$books = [];
+if ($search !== '') {
+    $books = search_google_books($search);
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Google Books Results</title>
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
+</head>
+<body class="pt-5">
+<?php include "navbar.php"; ?>
+<div class="container my-4">
+    <h1 class="mb-4">Google Books Results</h1>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Cover</th>
+                <th class="title-col">Title</th>
+                <th>Author(s)</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($books as $book): ?>
+            <tr>
+                <td>
+                    <?php if (!empty($book['imgUrl'])): ?>
+                        <img src="<?= htmlspecialchars($book['imgUrl']) ?>" alt="Cover" class="img-thumbnail" style="width: 150px; height: auto;">
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                </td>
+                <td class="title-col"><?= htmlspecialchars($book['title']) ?></td>
+                <td><?= $book['author'] !== '' ? htmlspecialchars($book['author']) : '&mdash;' ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/navbar.php
+++ b/navbar.php
@@ -2,6 +2,14 @@
 $searchVal = isset($search) ? $search : '';
 $sortVal = isset($sort) ? $sort : 'title';
 $sourceVal = isset($source) ? $source : 'local';
+$action = 'list_books.php';
+if ($sourceVal === 'openlibrary') {
+    $action = 'openlibrary_results.php';
+} elseif ($sourceVal === 'google') {
+    $action = 'google_results.php';
+} elseif ($sourceVal === 'annas') {
+    $action = 'annas_results.php';
+}
 $authorIdVal = isset($authorId) ? $authorId : null;
 $seriesIdVal = isset($seriesId) ? $seriesId : null;
 $genreIdVal = isset($genreId) ? $genreId : null;
@@ -15,7 +23,7 @@ $statusNameVal = isset($statusName) ? $statusName : '';
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarContent">
-      <form class="d-flex me-auto" method="get" action="list_books.php">
+      <form class="d-flex me-auto" method="get" action="<?= htmlspecialchars($action) ?>">
         <input type="hidden" name="page" value="1">
         <input type="hidden" name="sort" value="<?= htmlspecialchars($sortVal) ?>">
         <?php if ($authorIdVal): ?>
@@ -42,7 +50,7 @@ $statusNameVal = isset($statusName) ? $statusName : '';
         </select>
         <button class="btn btn-outline-secondary" type="submit">Search</button>
       </form>
-      <form class="d-flex" method="get" action="list_books.php">
+      <form class="d-flex" method="get" action="<?= htmlspecialchars($action) ?>">
         <input type="hidden" name="page" value="1">
         <?php if ($searchVal !== ''): ?>
           <input type="hidden" name="search" value="<?= htmlspecialchars($searchVal) ?>">

--- a/openlibrary_results.php
+++ b/openlibrary_results.php
@@ -1,0 +1,73 @@
+<?php
+require_once 'db.php';
+requireLogin();
+require_once 'openlibrary.php';
+
+$search = isset($_GET['search']) ? trim((string)$_GET['search']) : '';
+$sort = $_GET['sort'] ?? 'author_series';
+$source = 'openlibrary';
+$books = [];
+if ($search !== '') {
+    $books = search_openlibrary($search);
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Open Library Results</title>
+    <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="theme.js"></script>
+</head>
+<body class="pt-5">
+<?php include "navbar.php"; ?>
+<div class="container my-4">
+    <h1 class="mb-4">Open Library Results</h1>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Cover</th>
+                <th class="title-col">Title</th>
+                <th>Author(s)</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($books as $book): ?>
+            <tr>
+                <td>
+                    <?php if (!empty($book['cover_id'])): ?>
+                        <img src="https://covers.openlibrary.org/b/id/<?= htmlspecialchars($book['cover_id']) ?>-S.jpg" alt="Cover" class="img-thumbnail" style="width: 150px; height: auto;">
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                </td>
+                <td class="title-col">
+                    <a href="openlibrary_view.php?key=<?= urlencode($book['key']) ?>&title=<?= urlencode($book['title']) ?>&authors=<?= urlencode($book['authors']) ?>&cover_id=<?= urlencode((string)$book['cover_id']) ?>">
+                        <?= htmlspecialchars($book['title']) ?>
+                    </a>
+                </td>
+                <td>
+                    <?php if ($book['authors'] !== ''): ?>
+                        <?php
+                            $parts = array_map('trim', explode(',', $book['authors']));
+                            $display = implode(', ', array_slice($parts, 0, 3));
+                            if (count($parts) > 3) {
+                                $display .= '...';
+                            }
+                            echo htmlspecialchars($display);
+                        ?>
+                    <?php else: ?>
+                        &mdash;
+                    <?php endif; ?>
+                </td>
+                <td>&mdash;</td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move Open Library search results to `openlibrary_results.php`
- move Google Books results to `google_results.php`
- move Anna's Archive results to `annas_results.php`
- redirect remote queries from `list_books.php`
- update navbar to use new result pages

## Testing
- `php -l openlibrary_results.php`
- `php -l google_results.php`
- `php -l annas_results.php`
- `php -l list_books.php`
- `php -l navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_6883fa18bdc08329852222d2bca81426