### PR TITLE
Add Open Library cover fetch option

### DIFF
--- a/edit_book.php
+++ b/edit_book.php
@@ -19,41 +19,77 @@ $commentStmt = $pdo->prepare('SELECT text FROM comments WHERE book = ?');
 $commentStmt->execute([$id]);
 $description = $commentStmt->fetchColumn() ?: '';
 
+$openLibCoverUrl = '';
+$openLibExists = false;
+if (!empty($book['isbn'])) {
+    $openLibCoverUrl = 'https://covers.openlibrary.org/b/isbn/' . urlencode($book['isbn']) . '-L.jpg';
+    $headers = @get_headers($openLibCoverUrl);
+    if ($headers && strpos($headers[0], '200') !== false) {
+        $openLibExists = true;
+    }
+}
+
+$updated = false;
+$errorMessage = '';
+
 // Handle form submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $title = $_POST['title'] ?? '';
-    $descriptionInput = trim($_POST['description'] ?? '');
-
-    $pdo->beginTransaction();
-    $stmt = $pdo->prepare('UPDATE books SET title = ?, last_modified = CURRENT_TIMESTAMP WHERE id = ?');
-    $stmt->execute([$title, $id]);
-
-    if ($descriptionInput !== '') {
-        $descStmt = $pdo->prepare('INSERT INTO comments (book, text) VALUES (:book, :text) '
-            . 'ON CONFLICT(book) DO UPDATE SET text = excluded.text');
-        $descStmt->execute([':book' => $id, ':text' => $descriptionInput]);
-    } else {
-        $pdo->prepare('DELETE FROM comments WHERE book = ?')->execute([$id]);
-    }
-
-    if (!empty($_FILES['cover']) && $_FILES['cover']['error'] === UPLOAD_ERR_OK) {
-        $libraryPath = getLibraryPath();
-        $destDir = $libraryPath . '/' . $book['path'];
-        if (!is_dir($destDir)) {
-            mkdir($destDir, 0777, true);
+    if (isset($_POST['use_openlibrary_cover'])) {
+        if ($openLibExists) {
+            $imgData = @file_get_contents($openLibCoverUrl);
+            if ($imgData !== false) {
+                $libraryPath = getLibraryPath();
+                $destDir = $libraryPath . '/' . $book['path'];
+                if (!is_dir($destDir)) {
+                    mkdir($destDir, 0777, true);
+                }
+                file_put_contents($destDir . '/cover.jpg', $imgData);
+                $pdo->prepare('UPDATE books SET has_cover = 1 WHERE id = ?')->execute([$id]);
+                $updated = true;
+            } else {
+                $errorMessage = 'Failed to download cover from Open Library.';
+            }
+        } else {
+            $errorMessage = 'Open Library cover not available.';
         }
-        $destFile = $destDir . '/cover.jpg';
-        move_uploaded_file($_FILES['cover']['tmp_name'], $destFile);
-        $pdo->prepare('UPDATE books SET has_cover = 1 WHERE id = ?')->execute([$id]);
+        $stmt = $pdo->prepare('SELECT * FROM books WHERE id = ?');
+        $stmt->execute([$id]);
+        $book = $stmt->fetch(PDO::FETCH_ASSOC);
+    } else {
+        $title = $_POST['title'] ?? '';
+        $descriptionInput = trim($_POST['description'] ?? '');
+
+        $pdo->beginTransaction();
+        $stmt = $pdo->prepare('UPDATE books SET title = ?, last_modified = CURRENT_TIMESTAMP WHERE id = ?');
+        $stmt->execute([$title, $id]);
+
+        if ($descriptionInput !== '') {
+            $descStmt = $pdo->prepare('INSERT INTO comments (book, text) VALUES (:book, :text) '
+                . 'ON CONFLICT(book) DO UPDATE SET text = excluded.text');
+            $descStmt->execute([':book' => $id, ':text' => $descriptionInput]);
+        } else {
+            $pdo->prepare('DELETE FROM comments WHERE book = ?')->execute([$id]);
+        }
+
+        if (!empty($_FILES['cover']) && $_FILES['cover']['error'] === UPLOAD_ERR_OK) {
+            $libraryPath = getLibraryPath();
+            $destDir = $libraryPath . '/' . $book['path'];
+            if (!is_dir($destDir)) {
+                mkdir($destDir, 0777, true);
+            }
+            $destFile = $destDir . '/cover.jpg';
+            move_uploaded_file($_FILES['cover']['tmp_name'], $destFile);
+            $pdo->prepare('UPDATE books SET has_cover = 1 WHERE id = ?')->execute([$id]);
+        }
+
+        $pdo->commit();
+        $updated = true;
+
+        $stmt = $pdo->prepare('SELECT * FROM books WHERE id = ?');
+        $stmt->execute([$id]);
+        $book = $stmt->fetch(PDO::FETCH_ASSOC);
+        $description = $descriptionInput;
     }
-
-    $pdo->commit();
-    $updated = true;
-
-    $stmt = $pdo->prepare('SELECT * FROM books WHERE id = ?');
-    $stmt->execute([$id]);
-    $book = $stmt->fetch(PDO::FETCH_ASSOC);
-    $description = $descriptionInput;
 }
 ?>
 <!DOCTYPE html>
@@ -84,6 +120,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <?php if (!empty($updated)): ?>
                 <div class="alert alert-success">
                     <i class="fa-solid fa-circle-check me-2"></i> Book updated successfully
+                </div>
+            <?php endif; ?>
+            <?php if (!empty($errorMessage)): ?>
+                <div class="alert alert-danger">
+                    <i class="fa-solid fa-circle-exclamation me-2"></i> <?= htmlspecialchars($errorMessage) ?>
                 </div>
             <?php endif; ?>
 
@@ -117,16 +158,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <div class="mb-3">
         <p class="mb-1"><i class="fa-solid fa-eye me-1 text-success"></i> Current Cover:</p>
         <div class="position-relative d-inline-block">
-            <img id="coverImagePreview" 
-                 src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" 
-                 alt="Cover" 
-                 class="img-thumbnail shadow-sm" 
+            <img id="coverImagePreview"
+                 src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg"
+                 alt="Cover"
+                 class="img-thumbnail shadow-sm"
                  style="max-width: 200px;">
-            <div id="coverDimensions" 
-                 class="position-absolute bottom-0 end-0 bg-dark text-white px-2 py-1 small rounded-top-start opacity-75" 
+            <div id="coverDimensions"
+                 class="position-absolute bottom-0 end-0 bg-dark text-white px-2 py-1 small rounded-top-start opacity-75"
                  style="font-size: 1.2rem;">
                  Loading...
             </div>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php if ($openLibCoverUrl): ?>
+    <div class="mb-3">
+        <p class="mb-1"><i class="fa-solid fa-book-open me-1 text-info"></i> Open Library Cover:</p>
+        <div class="d-flex align-items-start">
+            <img src="<?= htmlspecialchars($openLibCoverUrl) ?>" alt="Open Library Cover" class="img-thumbnail shadow-sm" style="max-width: 200px;">
+            <?php if ($openLibExists): ?>
+                <form method="post" class="ms-3">
+                    <input type="hidden" name="use_openlibrary_cover" value="1">
+                    <button type="submit" class="btn btn-secondary">Use this</button>
+                </form>
+            <?php else: ?>
+                <span class="ms-3 text-muted">Cover not available</span>
+            <?php endif; ?>
         </div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- show the Open Library cover on the edit page when ISBN is available
- allow saving the Open Library image as the book's cover
- display error alerts if the cover download fails

## Testing
- `php -l edit_book.php`

------
https://chatgpt.com/codex/tasks/task_e_6884c16152388329a3ad34b96d88c61c