### PR TITLE
Initialize genre tables if missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `books_custom_column_10` table so they can be referenced later. If this table is missing from your database it will be created automatically the first time a recommendation is saved.
 
+When a different Calibre library is selected, the application ensures that all required custom tables (for genres, reading status, shelves and recommendations) are present in that database. Missing tables are created on the fly so the interface works with a fresh database without manual setup.
+
 Each book also has a "Shelf" value stored in the `books_custom_column_11` table. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
 Genres are stored in `custom_column_2` and listed in the sidebar. You can add,

--- a/db.php
+++ b/db.php
@@ -191,6 +191,10 @@ function initializeCustomColumns(PDO $pdo): void {
         // Recommendation storage column
         $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_10 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
 
+        // Genre tables used by the application
+        $pdo->exec("CREATE TABLE IF NOT EXISTS custom_column_2 (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value))");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_2_link (book INTEGER REFERENCES books(id) ON DELETE CASCADE, value INTEGER REFERENCES custom_column_2(id), PRIMARY KEY(book,value))");
+
         // Reading status column metadata
         $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
         $stmt->execute();


### PR DESCRIPTION
## Summary
- ensure custom `custom_column_2` tables are created for new databases
- clarify in README that missing custom tables are automatically created

## Testing
- `php -l db.php`
- `php -l add_genre.php`


------
https://chatgpt.com/codex/tasks/task_e_6884c5ea3e588329b811b5805b38e0db