### PR TITLE
Fix custom columns to match Calibre schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SQLite Books
 
-This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `books_custom_column_10` table so they can be referenced later. If this table is missing from your database it will be created automatically the first time a recommendation is saved.
+This project is a small PHP application for browsing and editing an eBook database. It now includes a PHP-based function for getting book recommendations from the OpenRouter API. Recommendations returned from the API are saved to the Calibre database in the `custom_column_10` table so they can be referenced later. If this table is missing from your database it will be created automatically the first time a recommendation is saved.
 
 When a different Calibre library is selected, the application ensures that all required custom tables (for genres, reading status, shelves and recommendations) are present in that database. Missing tables are created on the fly so the interface works with a fresh database without manual setup.
 
-Each book also has a "Shelf" value stored in the `books_custom_column_11` table. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
+Each book also has a "Shelf" value stored in the `custom_column_11` table. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
 Genres are stored in `custom_column_2` and listed in the sidebar. You can add,
 rename or delete genres from that list just like shelves and status values.

--- a/add_book.php
+++ b/add_book.php
@@ -38,39 +38,33 @@ try {
     $balStmt = $pdo->prepare('INSERT INTO books_authors_link (book, author) VALUES (:book, :author)');
     $balStmt->execute([':book' => $bookId, ':author' => $authorId]);
 
-    $tableStmt = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'books_custom_column_%'");
-    $tables = $tableStmt->fetchAll(PDO::FETCH_COLUMN);
-    foreach ($tables as $table) {
-        if (!preg_match('/^books_custom_column_(\d+)(?:_link)?$/', $table, $m)) {
-            continue;
-        }
-        $colId = (int)$m[1];
-        $isLink = str_ends_with($table, '_link');
-
-        if ($isLink) {
-            $infoStmt = $pdo->prepare('SELECT label, is_multiple FROM custom_columns WHERE id = :id');
-            $infoStmt->execute([':id' => $colId]);
-            $info = $infoStmt->fetch(PDO::FETCH_ASSOC);
-            if (!$info || (int)$info['is_multiple'] === 1) {
-                continue;
-            }
-            $valTable = 'custom_column_' . $colId;
+    $colStmt = $pdo->query("SELECT id, label, is_multiple FROM custom_columns");
+    $columns = $colStmt->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($columns as $col) {
+        $colId = (int)$col['id'];
+        $label = $col['label'];
+        $isMultiple = (int)$col['is_multiple'];
+        $linkTable = 'books_custom_column_' . $colId . '_link';
+        $valueTable = 'custom_column_' . $colId;
+        $linkExists = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $linkTable . "'")->fetchColumn();
+        $directExists = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $valueTable . "'")->fetchColumn();
+        if ($linkExists && $directExists && $isMultiple === 0) {
             $defaultId = null;
-            if ($info['label'] === 'status') {
-                $pdo->prepare("INSERT OR IGNORE INTO $valTable (value) VALUES ('Want to Read')")->execute();
-                $defaultId = $pdo->query("SELECT id FROM $valTable WHERE value = 'Want to Read'")->fetchColumn();
+            if ($label === '#status') {
+                $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES ('Want to Read')")->execute();
+                $defaultId = $pdo->query("SELECT id FROM $valueTable WHERE value = 'Want to Read'")->fetchColumn();
             } else {
-                $defaultId = $pdo->query("SELECT id FROM $valTable ORDER BY id LIMIT 1")->fetchColumn();
+                $defaultId = $pdo->query("SELECT id FROM $valueTable ORDER BY id LIMIT 1")->fetchColumn();
             }
             if ($defaultId !== false && $defaultId !== null) {
-                $pdo->prepare("INSERT INTO $table (book, value) VALUES (:book, :val)")->execute([':book' => $bookId, ':val' => $defaultId]);
+                $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :val)")->execute([':book' => $bookId, ':val' => $defaultId]);
             }
-        } else {
+        } elseif ($directExists) {
             $value = null;
-            if ($colId === 11) {
-                $value = 'Physical';
+            if ($label === '#shelf') {
+                $value = 'Ebook Calibre';
             }
-            $pdo->prepare("INSERT INTO $table (book, value) VALUES (:book, :value)")->execute([':book' => $bookId, ':value' => $value]);
+            $pdo->prepare("INSERT INTO $valueTable (book, value) VALUES (:book, :value)")->execute([':book' => $bookId, ':value' => $value]);
         }
     }
 

--- a/add_status.php
+++ b/add_status.php
@@ -12,7 +12,7 @@ if ($status === '') {
 
 $pdo = getDatabaseConnection();
 try {
-    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#status'");
     $stmt->execute();
     $statusId = $stmt->fetchColumn();
     if ($statusId === false) {
@@ -20,7 +20,7 @@ try {
         echo json_encode(['error' => 'Status column not found']);
         exit;
     }
-    $base = 'books_custom_column_' . (int)$statusId;
+    $base = 'custom_column_' . (int)$statusId;
     $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
     if ($link) {
         $valueTable = 'custom_column_' . (int)$statusId;

--- a/db.php
+++ b/db.php
@@ -185,26 +185,42 @@ function initializeCustomColumns(PDO $pdo): void {
         }
 
         // Shelf assignment column
-        $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_11 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
-        $pdo->exec("INSERT INTO books_custom_column_11 (book, value)\n                SELECT id, 'Ebook Calibre' FROM books\n                WHERE id NOT IN (SELECT book FROM books_custom_column_11)");
+        $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#shelf'");
+        $stmt->execute();
+        $shelfId = $stmt->fetchColumn();
+        if ($shelfId === false) {
+            $shelfId = (int)$pdo->query("SELECT COALESCE(MAX(id),0)+1 FROM custom_columns")->fetchColumn();
+            $pdo->prepare("INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES (:id, '#shelf', 'shelf', 'text', 0, 1, 0, 1, '{}')")->execute([':id' => $shelfId]);
+        }
+        $shelfTable = 'custom_column_' . (int)$shelfId;
+        $pdo->exec("CREATE TABLE IF NOT EXISTS $shelfTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+        $pdo->exec("INSERT INTO $shelfTable (book, value)\n              SELECT id, 'Ebook Calibre' FROM books\n                WHERE id NOT IN (SELECT book FROM $shelfTable)");
 
         // Recommendation storage column
-        $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_10 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
 
+        $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#recommendations'");
+        $stmt->execute();
+        $recId = $stmt->fetchColumn();
+        if ($recId === false) {
+            $recId = (int)$pdo->query("SELECT COALESCE(MAX(id),0)+1 FROM custom_columns")->fetchColumn();
+            $pdo->prepare("INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES (:id, '#recommendations', 'recommendations', 'text', 0, 1, 0, 1, '{}')")->execute([':id' => $recId]);
+        }
+        $recTable = 'custom_column_' . (int)$recId;
+        $pdo->exec("CREATE TABLE IF NOT EXISTS $recTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
         // Genre tables used by the application
         $pdo->exec("CREATE TABLE IF NOT EXISTS custom_column_2 (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value))");
         $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_2_link (book INTEGER REFERENCES books(id) ON DELETE CASCADE, value INTEGER REFERENCES custom_column_2(id), PRIMARY KEY(book,value))");
 
         // Reading status column metadata
-        $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+        $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#status'");
         $stmt->execute();
         $statusId = $stmt->fetchColumn();
         if ($statusId === false) {
             $statusId = (int)$pdo->query("SELECT COALESCE(MAX(id),0)+1 FROM custom_columns")->fetchColumn();
-            $insert = $pdo->prepare("INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES (:id, 'status', 'status', 'text', 0, 1, 0, 1, '{}')");
+            $insert = $pdo->prepare("INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES (:id, '#status', 'status', 'text', 0, 1, 0, 1, '{}')");
             $insert->execute([':id' => $statusId]);
         }
-        $statusTable = 'books_custom_column_' . (int)$statusId;
+        $statusTable = 'custom_column_' . (int)$statusId;
         $pdo->exec("CREATE TABLE IF NOT EXISTS $statusTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
         $pdo->exec("INSERT INTO $statusTable (book, value)\n                SELECT id, 'Want to Read' FROM books\n                WHERE id NOT IN (SELECT book FROM $statusTable)");
     } catch (PDOException $e) {

--- a/delete_shelf.php
+++ b/delete_shelf.php
@@ -14,7 +14,11 @@ $pdo = getDatabaseConnection();
 try {
     $stmt = $pdo->prepare('DELETE FROM shelves WHERE name = :name');
     $stmt->execute([':name' => $shelf]);
-    $update = $pdo->prepare("UPDATE books_custom_column_11 SET value = 'Ebook Calibre' WHERE value = :name");
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#shelf'");
+    $stmt->execute();
+    $shelfId = $stmt->fetchColumn();
+    $table = 'custom_column_' . (int)$shelfId;
+    $update = $pdo->prepare("UPDATE $table SET value = 'Ebook Calibre' WHERE value = :name");
     $update->execute([':name' => $shelf]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {

--- a/delete_status.php
+++ b/delete_status.php
@@ -12,7 +12,7 @@ if ($status === '') {
 
 $pdo = getDatabaseConnection();
 try {
-    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#status'");
     $stmt->execute();
     $statusId = $stmt->fetchColumn();
     if ($statusId === false) {
@@ -20,7 +20,7 @@ try {
         echo json_encode(['error' => 'Status column not found']);
         exit;
     }
-    $base = 'books_custom_column_' . (int)$statusId;
+    $base = 'custom_column_' . (int)$statusId;
     $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
     if ($link) {
         $valueTable = 'custom_column_' . (int)$statusId;

--- a/recommend.php
+++ b/recommend.php
@@ -26,25 +26,23 @@ try {
         // Ensure the recommendation column exists before storing the data
         $exists = false;
         try {
-            $check = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='books_custom_column_10'");
-            if ($check->fetch()) {
-                $exists = true;
+            $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#recommendations'");
+            $stmt->execute();
+            $recId = $stmt->fetchColumn();
+            if ($recId === false) {
+                $recId = (int)$pdo->query("SELECT COALESCE(MAX(id),0)+1 FROM custom_columns")->fetchColumn();
+                $pdo->prepare("INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES (:id, '#recommendations', 'recommendations', 'text', 0, 1, 0, 1, '{}')")
+                    ->execute([':id' => $recId]);
             }
+            $recTable = 'custom_column_' . (int)$recId;
+            $pdo->exec("CREATE TABLE IF NOT EXISTS $recTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+            $exists = true;
         } catch (PDOException $e) {
             $exists = false;
         }
-        if (!$exists) {
-            try {
-                $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_10 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
-                $exists = true;
-            } catch (PDOException $e) {
-                // If creation fails we still continue without saving
-                $exists = false;
-            }
-        }
 
         if ($exists) {
-            $stmt = $pdo->prepare('REPLACE INTO books_custom_column_10 (book, value) VALUES (:book, :value)');
+            $stmt = $pdo->prepare('REPLACE INTO ' . $recTable . ' (book, value) VALUES (:book, :value)');
             $stmt->execute([':book' => $bookId, ':value' => $output]);
         }
     }

--- a/rename_shelf.php
+++ b/rename_shelf.php
@@ -16,7 +16,11 @@ try {
     $pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
     $pdo->beginTransaction();
     $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (:new)')->execute([':new' => $new]);
-    $pdo->prepare('UPDATE books_custom_column_11 SET value = :new WHERE value = :old')->execute([':new' => $new, ':old' => $old]);
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#shelf'");
+    $stmt->execute();
+    $shelfId = $stmt->fetchColumn();
+    $table = 'custom_column_' . (int)$shelfId;
+    $pdo->prepare("UPDATE $table SET value = :new WHERE value = :old")->execute([':new' => $new, ':old' => $old]);
     $pdo->prepare('DELETE FROM shelves WHERE name = :old')->execute([':old' => $old]);
     $pdo->commit();
     echo json_encode(['status' => 'ok']);

--- a/rename_status.php
+++ b/rename_status.php
@@ -13,7 +13,7 @@ if ($old === '' || $new === '') {
 
 $pdo = getDatabaseConnection();
 try {
-    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#status'");
     $stmt->execute();
     $statusId = $stmt->fetchColumn();
     if ($statusId === false) {
@@ -21,7 +21,7 @@ try {
         echo json_encode(['error' => 'Status column not found']);
         exit;
     }
-    $base = 'books_custom_column_' . (int)$statusId;
+    $base = 'custom_column_' . (int)$statusId;
     $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
     if ($link) {
         $valueTable = 'custom_column_' . (int)$statusId;

--- a/schema.sql
+++ b/schema.sql
@@ -1120,5 +1120,5 @@ CREATE VIEW tag_browser_filtered_custom_column_9 AS SELECT
                            books_list_filter(bl.book)) avg_rating,
                     value AS sort
                 FROM custom_column_9;
-CREATE TABLE books_custom_column_10 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT);
-CREATE TABLE books_custom_column_11 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT);
+CREATE TABLE custom_column_10 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT);
+CREATE TABLE custom_column_11 (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT);

--- a/update_shelf.php
+++ b/update_shelf.php
@@ -20,7 +20,11 @@ if ($bookId <= 0 || !in_array($value, $allowed, true)) {
     exit;
 }
 
-$stmt = $pdo->prepare('REPLACE INTO books_custom_column_11 (book, value) VALUES (:book, :value)');
+$stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#shelf'");
+$stmt->execute();
+$shelfId = $stmt->fetchColumn();
+$table = 'custom_column_' . (int)$shelfId;
+$stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :value)");
 $stmt->execute([':book' => $bookId, ':value' => $value]);
 
 echo json_encode(['status' => 'ok']);

--- a/update_status.php
+++ b/update_status.php
@@ -13,7 +13,7 @@ try {
     if (!in_array('read_date', $cols, true)) {
         $pdo->exec("ALTER TABLE reading_log ADD COLUMN read_date TEXT");
     }
-    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = 'status'");
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#status'");
     $stmt->execute();
     $statusId = $stmt->fetchColumn();
     if ($statusId === false) {
@@ -22,7 +22,7 @@ try {
         exit;
     }
 
-    $base = 'books_custom_column_' . (int)$statusId;
+    $base = 'custom_column_' . (int)$statusId;
     $direct = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "'")->fetchColumn();
     $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
 

--- a/view_book.php
+++ b/view_book.php
@@ -44,11 +44,19 @@ $tagsStmt = $pdo->prepare("SELECT GROUP_CONCAT(t.name, ', ')
 $tagsStmt->execute([$id]);
 $tags = $tagsStmt->fetchColumn();
 
-// Fetch saved recommendations from custom column 10, if present
+// Fetch saved recommendations from custom column if present
 try {
-    $recStmt = $pdo->prepare('SELECT value FROM books_custom_column_10 WHERE book = ?');
-    $recStmt->execute([$id]);
-    $savedRecommendations = $recStmt->fetchColumn();
+    $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#recommendations'");
+    $stmt->execute();
+    $recId = $stmt->fetchColumn();
+    if ($recId !== false) {
+        $recTable = 'custom_column_' . (int)$recId;
+        $recStmt = $pdo->prepare('SELECT value FROM ' . $recTable . ' WHERE book = ?');
+        $recStmt->execute([$id]);
+        $savedRecommendations = $recStmt->fetchColumn();
+    } else {
+        $savedRecommendations = null;
+    }
 } catch (PDOException $e) {
     // Table may not exist in some databases
     $savedRecommendations = null;


### PR DESCRIPTION
## Summary
- refactor all custom column handling to use Calibre's `custom_column_X` naming
- register `#shelf`, `#status` and `#recommendations` columns in `custom_columns`
- update queries to lookup column ids dynamically
- adjust README and schema to document correct table names

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6884d499eec08329976db67c37069b26