### PR TITLE
Fix recommendations column detection

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -79,17 +79,25 @@ try {
 }
 
 
-// Check if the recommendations table exists
+// Check if the recommendations table exists (direct or link form)
 $recColumnExists = false;
 try {
     $stmt = $pdo->prepare("SELECT id FROM custom_columns WHERE label = '#recommendations'");
     $stmt->execute();
     $recId = $stmt->fetchColumn();
     if ($recId !== false) {
-        $recTable = 'custom_column_' . (int)$recId;
-        $check = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $recTable . "'");
-        if ($check->fetch()) {
+        $base = 'custom_column_' . (int)$recId;
+        $link = 'books_custom_column_' . (int)$recId . '_link';
+        $linkCheck = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $link . "'");
+        if ($linkCheck->fetch()) {
+            $recTable = $link;
             $recColumnExists = true;
+        } else {
+            $baseCheck = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "'");
+            if ($baseCheck->fetch()) {
+                $recTable = $base;
+                $recColumnExists = true;
+            }
         }
     }
 } catch (PDOException $e) {

--- a/recommend.php
+++ b/recommend.php
@@ -34,8 +34,15 @@ try {
                 $pdo->prepare("INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES (:id, '#recommendations', 'recommendations', 'text', 0, 1, 0, 1, '{}')")
                     ->execute([':id' => $recId]);
             }
-            $recTable = 'custom_column_' . (int)$recId;
-            $pdo->exec("CREATE TABLE IF NOT EXISTS $recTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+            $base = 'custom_column_' . (int)$recId;
+            $link = 'books_custom_column_' . (int)$recId . '_link';
+            $linkCheck = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $link . "'");
+            if ($linkCheck->fetch()) {
+                $recTable = $link;
+            } else {
+                $recTable = $base;
+                $pdo->exec("CREATE TABLE IF NOT EXISTS $recTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
+            }
             $exists = true;
         } catch (PDOException $e) {
             $exists = false;

--- a/view_book.php
+++ b/view_book.php
@@ -50,7 +50,14 @@ try {
     $stmt->execute();
     $recId = $stmt->fetchColumn();
     if ($recId !== false) {
-        $recTable = 'custom_column_' . (int)$recId;
+        $base = 'custom_column_' . (int)$recId;
+        $link = 'books_custom_column_' . (int)$recId . '_link';
+        $linkCheck = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $link . "'");
+        if ($linkCheck->fetch()) {
+            $recTable = $link;
+        } else {
+            $recTable = $base;
+        }
         $recStmt = $pdo->prepare('SELECT value FROM ' . $recTable . ' WHERE book = ?');
         $recStmt->execute([$id]);
         $savedRecommendations = $recStmt->fetchColumn();


### PR DESCRIPTION
## Summary
- handle existing recommendations column stored as a link table
- fall back to using link table when reading or writing recommendations

## Testing
- `php -l list_books.php`
- `php -l recommend.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_6884d8b6713c8329931e7198f82c017c