### PR TITLE
Ensure dynamic genre and status columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ When a different Calibre library is selected, the application ensures that all r
 
 Each book also has a "Shelf" value stored in the `books_custom_column_11` table. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
-Genres are stored in `custom_column_2` and listed in the sidebar. You can add,
+Genres are stored in the custom column labeled `genre` and listed in the sidebar. You can add,
 rename or delete genres from that list just like shelves and status values.
 
 ## Preferences

--- a/add_genre.php
+++ b/add_genre.php
@@ -12,8 +12,8 @@ if ($genre === '') {
 
 $pdo = getDatabaseConnection();
 try {
-    $pdo->exec("CREATE TABLE IF NOT EXISTS custom_column_2 (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value))");
-    $stmt = $pdo->prepare('INSERT OR IGNORE INTO custom_column_2 (value) VALUES (:val)');
+    [, $valueTable, ] = ensureMultivalueColumn($pdo, 'genre');
+    $stmt = $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)");
     $stmt->execute([':val' => $genre]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {

--- a/delete_genre.php
+++ b/delete_genre.php
@@ -12,7 +12,9 @@ if ($id <= 0) {
 
 $pdo = getDatabaseConnection();
 try {
-    $stmt = $pdo->prepare('DELETE FROM custom_column_2 WHERE id = :id');
+    [, $valueTable, $linkTable] = ensureMultivalueColumn($pdo, 'genre');
+    $pdo->prepare("DELETE FROM $linkTable WHERE value = :id")->execute([':id' => $id]);
+    $stmt = $pdo->prepare("DELETE FROM $valueTable WHERE id = :id");
     $stmt->execute([':id' => $id]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {

--- a/rename_genre.php
+++ b/rename_genre.php
@@ -13,21 +13,22 @@ if ($id <= 0 || $new === '') {
 
 $pdo = getDatabaseConnection();
 try {
-    $stmt = $pdo->prepare('SELECT id FROM custom_column_2 WHERE id = :id');
+    [$genreId, $valueTable, $linkTable] = ensureMultivalueColumn($pdo, 'genre');
+    $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE id = :id");
     $stmt->execute([':id' => $id]);
     if ($stmt->fetchColumn() === false) {
         http_response_code(400);
         echo json_encode(['error' => 'Genre not found']);
         exit;
     }
-    $stmt = $pdo->prepare('SELECT id FROM custom_column_2 WHERE value = :val');
+    $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
     $stmt->execute([':val' => $new]);
     $existingId = $stmt->fetchColumn();
     if ($existingId === false) {
-        $pdo->prepare('UPDATE custom_column_2 SET value = :val WHERE id = :id')->execute([':val' => $new, ':id' => $id]);
+        $pdo->prepare("UPDATE $valueTable SET value = :val WHERE id = :id")->execute([':val' => $new, ':id' => $id]);
     } else {
-        $pdo->prepare('UPDATE books_custom_column_2_link SET value = :newid WHERE value = :oldid')->execute([':newid' => $existingId, ':oldid' => $id]);
-        $pdo->prepare('DELETE FROM custom_column_2 WHERE id = :id')->execute([':id' => $id]);
+        $pdo->prepare("UPDATE $linkTable SET value = :newid WHERE value = :oldid")->execute([':newid' => $existingId, ':oldid' => $id]);
+        $pdo->prepare("DELETE FROM $valueTable WHERE id = :id")->execute([':id' => $id]);
     }
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {

--- a/update_genre.php
+++ b/update_genre.php
@@ -15,22 +15,21 @@ if ($bookId <= 0) {
 $pdo = getDatabaseConnection();
 
 try {
-    $pdo->exec("CREATE TABLE IF NOT EXISTS custom_column_2 (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value))");
-    $pdo->exec("CREATE TABLE IF NOT EXISTS books_custom_column_2_link (book INTEGER REFERENCES books(id) ON DELETE CASCADE, value INTEGER REFERENCES custom_column_2(id), PRIMARY KEY(book,value))");
+    [$genreId, $valueTable, $linkTable] = ensureMultivalueColumn($pdo, 'genre');
 
-    $pdo->prepare('DELETE FROM books_custom_column_2_link WHERE book = :book')->execute([':book' => $bookId]);
+    $pdo->prepare("DELETE FROM $linkTable WHERE book = :book")->execute([':book' => $bookId]);
 
     if ($value !== '') {
-        $genreId = (int)$value;
-        $stmt = $pdo->prepare('SELECT id FROM custom_column_2 WHERE id = :id');
-        $stmt->execute([':id' => $genreId]);
+        $genreIdVal = (int)$value;
+        $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE id = :id");
+        $stmt->execute([':id' => $genreIdVal]);
         if ($stmt->fetchColumn() === false) {
             http_response_code(400);
             echo json_encode(['error' => 'Invalid genre']);
             exit;
         }
-        $stmt = $pdo->prepare('INSERT INTO books_custom_column_2_link (book, value) VALUES (:book, :value)');
-        $stmt->execute([':book' => $bookId, ':value' => $genreId]);
+        $stmt = $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :value)");
+        $stmt->execute([':book' => $bookId, ':value' => $genreIdVal]);
     }
 
     echo json_encode(['status' => 'ok']);


### PR DESCRIPTION
## Summary
- initialize `genre` and `status` columns dynamically
- provide helpers to locate or create multi-value columns
- update genre handlers to use dynamic column tables
- adjust book listing queries to use the dynamic genre tables
- clarify documentation about the genre column

## Testing
- `php -l db.php`
- `php -l update_genre.php`
- `php -l add_genre.php`
- `php -l rename_genre.php`
- `php -l delete_genre.php`
- `php -l list_books.php`
- `php -l delete_status.php`
- `php -l rename_status.php`
- `php -l add_status.php`
- `php -l update_status.php`

------
https://chatgpt.com/codex/tasks/task_e_6884e9ee68f88329bcfbf5008d0a9f76