### PR TITLE
Fix custom column queries

### DIFF
--- a/add_col.sh
+++ b/add_col.sh
@@ -10,10 +10,11 @@ NEXT_ID=$(sqlite3 "$DB" "SELECT COALESCE(MAX(id), 0) + 1 FROM custom_columns;")
 # Insert into custom_columns (no search_terms column)
 sqlite3 "$DB" "INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES ($NEXT_ID, 'shelfs', 'myshelf', 'text', 0, 1, 0, 1, '{}');"
 
-# Create the books_custom_column_X table
-sqlite3 "$DB" "CREATE TABLE books_custom_column_${NEXT_ID} (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT);"
+# Create the value and link tables for the new column
+sqlite3 "$DB" "CREATE TABLE custom_column_${NEXT_ID} (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value));"
+sqlite3 "$DB" "CREATE TABLE books_custom_column_${NEXT_ID}_link (id INTEGER PRIMARY KEY AUTOINCREMENT, book INTEGER NOT NULL, value INTEGER NOT NULL, UNIQUE(book, value));"
 
-# Populate with NULL for all existing books
-sqlite3 "$DB" "INSERT INTO books_custom_column_${NEXT_ID} (book, value) SELECT id, NULL FROM books;"
+# Populate default NULL entry for existing books
+sqlite3 "$DB" "INSERT INTO books_custom_column_${NEXT_ID}_link (book, value) SELECT id, NULL FROM books;"
 
 echo "Custom column #airecomend (airecomends) created with ID: $NEXT_ID"

--- a/add_genre.php
+++ b/add_genre.php
@@ -13,8 +13,9 @@ if ($genre === '') {
 $pdo = getDatabaseConnection();
 try {
     $genreId = ensureMultiValueColumn($pdo, '#genre', 'Genre');
-    // Calibre 8.5 stores multi-value options in the link table only,
-    // so there is no separate values table to insert into.
+    $valueTable = "custom_column_{$genreId}";
+    $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+        ->execute([':val' => $genre]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/add_status.php
+++ b/add_status.php
@@ -20,17 +20,10 @@ try {
         echo json_encode(['error' => 'Status column not found']);
         exit;
     }
-    $base = 'books_custom_column_' . (int)$statusId;
-    $link = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='" . $base . "_link'")->fetchColumn();
-    if ($link) {
-        $valueTable = 'custom_column_' . (int)$statusId;
-        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")->execute([':val' => $status]);
-    } else {
-        // For non-enumerated columns just insert into the main table for filtering
-        $valueTable = $base;
-        $pdo->exec("CREATE TABLE IF NOT EXISTS $valueTable (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, value TEXT)");
-        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (book, value) SELECT id, :val FROM books WHERE 0")->execute([':val' => $status]);
-    }
+
+    $valueTable = 'custom_column_' . (int)$statusId;
+    $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+        ->execute([':val' => $status]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/delete_genre.php
+++ b/delete_genre.php
@@ -13,8 +13,16 @@ if ($genre === '') {
 $pdo = getDatabaseConnection();
 try {
     $genreId = ensureMultiValueColumn($pdo, '#genre', 'Genre');
+    $valueTable = "custom_column_{$genreId}";
     $linkTable = "books_custom_column_{$genreId}_link";
-    $pdo->prepare("DELETE FROM $linkTable WHERE value = :val")->execute([':val' => $genre]);
+
+    $valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+    $valStmt->execute([':val' => $genre]);
+    $gid = $valStmt->fetchColumn();
+    if ($gid !== false) {
+        $pdo->prepare("DELETE FROM $linkTable WHERE value = :id")->execute([':id' => $gid]);
+        $pdo->prepare("DELETE FROM $valueTable WHERE id = :id")->execute([':id' => $gid]);
+    }
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/import.py
+++ b/import.py
@@ -138,8 +138,13 @@ with open(CSV_FILE, newline='', encoding='utf-8') as csvfile:
                 SELECT ?, id FROM {custom_value_table} WHERE value=?;
             """, (book_id, CUSTOM_COLUMN_VALUE))
         else:
-            custom_table = f"books_custom_column_{CUSTOM_COLUMN_ID}"
-            cur.execute(f"INSERT OR REPLACE INTO {custom_table} (book, value) VALUES (?, ?);", (book_id, CUSTOM_COLUMN_VALUE))
+            custom_value_table = f"custom_column_{CUSTOM_COLUMN_ID}"
+            custom_link_table = f"books_custom_column_{CUSTOM_COLUMN_ID}_link"
+            cur.execute(f"INSERT OR IGNORE INTO {custom_value_table} (value) VALUES (?);", (CUSTOM_COLUMN_VALUE,))
+            cur.execute(f"""
+                INSERT OR REPLACE INTO {custom_link_table} (book, value)
+                SELECT ?, id FROM {custom_value_table} WHERE value=?;
+            """, (book_id, CUSTOM_COLUMN_VALUE))
         conn.commit()
 
         # 7. Create folder structure

--- a/rename_genre.php
+++ b/rename_genre.php
@@ -14,8 +14,8 @@ if ($old === '' || $new === '') {
 $pdo = getDatabaseConnection();
 try {
     $genreId = ensureMultiValueColumn($pdo, '#genre', 'Genre');
-    $linkTable = "books_custom_column_{$genreId}_link";
-    $pdo->prepare("UPDATE $linkTable SET value = :new WHERE value = :old")->execute([':new' => $new, ':old' => $old]);
+    $valueTable = "custom_column_{$genreId}";
+    $pdo->prepare("UPDATE $valueTable SET value = :new WHERE value = :old")->execute([':new' => $new, ':old' => $old]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/rename_status.php
+++ b/rename_status.php
@@ -14,8 +14,8 @@ if ($old === '' || $new === '') {
 $pdo = getDatabaseConnection();
 try {
     $statusId = ensureMultiValueColumn($pdo, '#status', 'Status');
-    $linkTable = "books_custom_column_{$statusId}_link";
-    $pdo->prepare("UPDATE $linkTable SET value = :new WHERE value = :old")
+    $valueTable = "custom_column_{$statusId}";
+    $pdo->prepare("UPDATE $valueTable SET value = :new WHERE value = :old")
         ->execute([':new' => $new, ':old' => $old]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {

--- a/view_book.php
+++ b/view_book.php
@@ -44,9 +44,12 @@ $tagsStmt = $pdo->prepare("SELECT GROUP_CONCAT(t.name, ', ')
 $tagsStmt->execute([$id]);
 $tags = $tagsStmt->fetchColumn();
 
-// Fetch saved recommendations from custom column 10, if present
+// Fetch saved recommendations from custom column, if present
 try {
-    $recStmt = $pdo->prepare('SELECT value FROM books_custom_column_10 WHERE book = ?');
+    $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
+    $valueTable = "custom_column_{$recId}";
+    $linkTable  = "books_custom_column_{$recId}_link";
+    $recStmt = $pdo->prepare("SELECT v.value FROM $linkTable l JOIN $valueTable v ON l.value = v.id WHERE l.book = ?");
     $recStmt->execute([$id]);
     $savedRecommendations = $recStmt->fetchColumn();
 } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- update PHP scripts to use new custom column tables
- update add_col helper for new schema
- update import script logic
- switch list_books queries to join via link tables
- update view and recommendation logic

## Testing
- `php -l add_book.php add_genre.php add_status.php delete_genre.php delete_shelf.php delete_status.php list_books.php recommend.php rename_genre.php rename_status.php update_genre.php update_shelf.php update_status.php view_book.php`
- `python3 -m py_compile import.py`

------
https://chatgpt.com/codex/tasks/task_e_6885fbecfa2c8329a9e6bfe25db97460