### PR TITLE
Fix single-value custom column schema

### DIFF
--- a/add_book.php
+++ b/add_book.php
@@ -40,11 +40,9 @@ try {
 
     // Assign default shelf
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $shelfValTable = "custom_column_{$shelfId}";
-    $shelfLinkTable = "books_custom_column_{$shelfId}_link";
-    $pdo->prepare("INSERT OR IGNORE INTO $shelfValTable (value) VALUES ('Ebook Calibre')")->execute();
-    $shelfValId = $pdo->query("SELECT id FROM $shelfValTable WHERE value = 'Ebook Calibre'")->fetchColumn();
-    $pdo->prepare("INSERT INTO $shelfLinkTable (book, value) VALUES (:book, :val)")->execute([':book' => $bookId, ':val' => $shelfValId]);
+    $shelfTable = "custom_column_{$shelfId}";
+    $stmt = $pdo->prepare("INSERT OR IGNORE INTO $shelfTable (book, value) VALUES (:book, :val)");
+    $stmt->execute([':book' => $bookId, ':val' => 'Ebook Calibre']);
 
     // Assign default status
     $statusId = ensureMultiValueColumn($pdo, '#status', 'Status');

--- a/delete_shelf.php
+++ b/delete_shelf.php
@@ -15,18 +15,10 @@ try {
     $stmt = $pdo->prepare('DELETE FROM shelves WHERE name = :name');
     $stmt->execute([':name' => $shelf]);
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $valueTable = "custom_column_{$shelfId}";
-    $linkTable  = "books_custom_column_{$shelfId}_link";
+    $table = "custom_column_{$shelfId}";
 
-    $valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
-    $valStmt->execute([':val' => $shelf]);
-    $oldId = $valStmt->fetchColumn();
-    if ($oldId !== false) {
-        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES ('Ebook Calibre')")->execute();
-        $defId = $pdo->query("SELECT id FROM $valueTable WHERE value = 'Ebook Calibre'")->fetchColumn();
-        $pdo->prepare("UPDATE $linkTable SET value = :def WHERE value = :old")->execute([':def' => $defId, ':old' => $oldId]);
-        $pdo->prepare("DELETE FROM $valueTable WHERE id = :id")->execute([':id' => $oldId]);
-    }
+    $stmt = $pdo->prepare("UPDATE $table SET value = 'Ebook Calibre' WHERE value = :old");
+    $stmt->execute([':old' => $shelf]);
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/recommend.php
+++ b/recommend.php
@@ -24,14 +24,9 @@ try {
         $pdo = getDatabaseConnection();
 
         $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-        $valueTable = "custom_column_{$recId}";
-        $linkTable  = "books_custom_column_{$recId}_link";
-        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")->execute([':val' => $output]);
-        $valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
-        $valStmt->execute([':val' => $output]);
-        $valId = $valStmt->fetchColumn();
-        $stmt = $pdo->prepare("REPLACE INTO $linkTable (book, value) VALUES (:book, :val)");
-        $stmt->execute([':book' => $bookId, ':val' => $valId]);
+        $table = "custom_column_{$recId}";
+        $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
+        $stmt->execute([':book' => $bookId, ':val' => $output]);
     }
 
     echo json_encode(['output' => $output]);

--- a/update_shelf.php
+++ b/update_shelf.php
@@ -21,18 +21,10 @@ if ($bookId <= 0 || !in_array($value, $allowed, true)) {
 }
 
 $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-$valueTable = "custom_column_{$shelfId}";
-$linkTable  = "books_custom_column_{$shelfId}_link";
+$table = "custom_column_{$shelfId}";
 
-// Ensure the shelf value exists
-$pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
-    ->execute([':val' => $value]);
-$valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
-$valStmt->execute([':val' => $value]);
-$valId = $valStmt->fetchColumn();
-
-$stmt = $pdo->prepare("REPLACE INTO $linkTable (book, value) VALUES (:book, :val)");
-$stmt->execute([':book' => $bookId, ':val' => $valId]);
+$stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
+$stmt->execute([':book' => $bookId, ':val' => $value]);
 
 echo json_encode(['status' => 'ok']);
 ?>

--- a/view_book.php
+++ b/view_book.php
@@ -47,9 +47,8 @@ $tags = $tagsStmt->fetchColumn();
 // Fetch saved recommendations from custom column, if present
 try {
     $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-    $valueTable = "custom_column_{$recId}";
-    $linkTable  = "books_custom_column_{$recId}_link";
-    $recStmt = $pdo->prepare("SELECT v.value FROM $linkTable l JOIN $valueTable v ON l.value = v.id WHERE l.book = ?");
+    $table = "custom_column_{$recId}";
+    $recStmt = $pdo->prepare("SELECT value FROM $table WHERE book = ?");
     $recStmt->execute([$id]);
     $savedRecommendations = $recStmt->fetchColumn();
 } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- fix custom column table creation for single-value columns
- adjust helpers to insert default value for single-value columns
- update scripts that interact with Shelf and Recommendation columns

## Testing
- `php -l db.php`
- `php -l add_book.php`
- `php -l delete_shelf.php`
- `php -l update_shelf.php`
- `php -l list_books.php`
- `php -l recommend.php`
- `php -l view_book.php`


------
https://chatgpt.com/codex/tasks/task_e_688616ad0d7c8329a5fba0a0e87468b7