### PR TITLE
Make library path configurable

### DIFF
--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -8,10 +8,7 @@ function safe_filename(string $name, int $max_length = 150): string {
 }
 
 $pdo = getDatabaseConnection();
-$libraryPath = realpath(__DIR__ . '/ebooks');
-if ($libraryPath === false) {
-    $libraryPath = __DIR__ . '/ebooks';
-}
+$libraryPath = getLibraryPath();
 
 $message = '';
 $errors = [];

--- a/custom_column.php
+++ b/custom_column.php
@@ -1,5 +1,6 @@
 <?php
-$pdo = new PDO('sqlite:ebooks/metadata.db');
+require_once 'db.php';
+$pdo = new PDO('sqlite:' . getLibraryPath() . '/metadata.db');
 // this shows how to create multi-value and single-value calibre multi-value structure for single-value
 // Create single-value column: shelf
 $pdo->exec("

--- a/db.php
+++ b/db.php
@@ -97,7 +97,14 @@ function currentDatabasePath(): string {
 }
 
 function getLibraryPath(): string {
-    return dirname(currentDatabasePath());
+    $user = currentUser();
+    if ($user) {
+        $path = getUserPreference($user, 'library_path');
+        if ($path) {
+            return rtrim($path, '/');
+        }
+    }
+    return rtrim(getPreference('library_path', 'ebooks'), '/');
 }
 
 function bookHasFile(string $relativePath): bool {

--- a/edit_book.php
+++ b/edit_book.php
@@ -117,10 +117,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <div class="mb-3">
         <p class="mb-1"><i class="fa-solid fa-eye me-1 text-success"></i> Current Cover:</p>
         <div class="position-relative d-inline-block">
-            <img id="coverImagePreview" 
-                 src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" 
-                 alt="Cover" 
-                 class="img-thumbnail shadow-sm" 
+            <img id="coverImagePreview"
+                 src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>"
+                 alt="Cover"
+                 class="img-thumbnail shadow-sm"
                  style="max-width: 200px;">
             <div id="coverDimensions" 
                  class="position-absolute bottom-0 end-0 bg-dark text-white px-2 py-1 small rounded-top-start opacity-75" 

--- a/list_books.php
+++ b/list_books.php
@@ -300,7 +300,7 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
             <div class="col-md-2 col-12 text-center cover-wrapper">
                 <?php if (!empty($book['has_cover'])): ?>
                     <a href="view_book.php?id=<?= urlencode($book['id']) ?>">
-                        <img src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg"
+                        <img src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>"
                              alt="Cover"
                              class="img-thumbnail img-fluid book-cover"
                              style="width: 100%; max-width:150px; height:auto;">

--- a/preferences.json
+++ b/preferences.json
@@ -1,3 +1,4 @@
 {
-    "db_path": "metadata.old.db"
+    "db_path": "metadata.old.db",
+    "library_path": "ebooks"
 }

--- a/preferences.php
+++ b/preferences.php
@@ -5,27 +5,42 @@ requireLogin();
 $message = '';
 $alertClass = 'success';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $newPath = trim($_POST['db_path'] ?? '');
-    if ($newPath !== '') {
-        setUserPreference(currentUser(), 'db_path', $newPath);
+    $dbPath = trim($_POST['db_path'] ?? '');
+    $libPath = trim($_POST['library_path'] ?? '');
+
+    if ($dbPath !== '') {
+        setUserPreference(currentUser(), 'db_path', $dbPath);
         if (isset($_POST['save_global'])) {
-            setPreference('db_path', $newPath);
+            setPreference('db_path', $dbPath);
         }
+    }
 
-        $writable = file_exists($newPath)
-            ? is_writable($newPath)
-            : (is_dir(dirname($newPath)) && is_writable(dirname($newPath)));
+    if ($libPath !== '') {
+        setUserPreference(currentUser(), 'library_path', $libPath);
+        if (isset($_POST['save_global'])) {
+            setPreference('library_path', $libPath);
+        }
+    }
 
-        if ($writable) {
-            $message = 'Preferences saved.';
-        } else {
+    $dbWritable = $dbPath === '' ? true : (file_exists($dbPath)
+        ? is_writable($dbPath)
+        : (is_dir(dirname($dbPath)) && is_writable(dirname($dbPath))));
+    $libWritable = $libPath === '' ? true : (is_dir($libPath) && is_writable($libPath));
+
+    if ($dbWritable && $libWritable) {
+        $message = 'Preferences saved.';
+    } else {
+        $alertClass = 'danger';
+        if (!$dbWritable) {
             $message = 'Database path is not writable.';
-            $alertClass = 'danger';
+        } elseif (!$libWritable) {
+            $message = 'Library path is not writable.';
         }
     }
 }
 
 $currentPath = currentDatabasePath();
+$currentLibrary = getLibraryPath();
 ?>
 <!doctype html>
 <html lang="en">
@@ -44,6 +59,10 @@ $currentPath = currentDatabasePath();
   <div class="mb-3">
     <label for="db_path" class="form-label">Calibre database path</label>
     <input type="text" id="db_path" name="db_path" class="form-control" value="<?php echo htmlspecialchars($currentPath); ?>">
+  </div>
+  <div class="mb-3">
+    <label for="library_path" class="form-label">Calibre library path</label>
+    <input type="text" id="library_path" name="library_path" class="form-control" value="<?php echo htmlspecialchars($currentLibrary); ?>">
   </div>
   <div class="mb-3">
     <label for="themeSelect" class="form-label">Theme</label>

--- a/reading_challenges.php
+++ b/reading_challenges.php
@@ -250,7 +250,7 @@ try {
                 <div class="col">
                     <div class="card h-100 shadow-sm">
                         <?php if (!empty($b['has_cover'])): ?>
-                            <img src="ebooks/<?= htmlspecialchars($b['path']) ?>/cover.jpg" alt="Cover" class="card-img-top" style="height: 600px; object-fit: cover;">
+                            <img src="<?= htmlspecialchars(getLibraryPath() . '/' . $b['path'] . '/cover.jpg') ?>" alt="Cover" class="card-img-top" style="height: 600px; object-fit: cover;">
                         <?php else: ?>
                             <div class="card-img-top bg-light d-flex align-items-center justify-content-center" style="height: 600px;">
                                 <i class="fa-solid fa-book fa-3x text-secondary"></i>

--- a/update_metadata.php
+++ b/update_metadata.php
@@ -28,10 +28,7 @@ try {
         $pathStmt->execute([':id' => $bookId]);
         $bookPath = $pathStmt->fetchColumn();
         if ($bookPath !== false) {
-            $libraryPath = realpath(__DIR__ . '/ebooks');
-            if ($libraryPath === false) {
-                $libraryPath = __DIR__ . '/ebooks';
-            }
+            $libraryPath = getLibraryPath();
             $data = @file_get_contents($imgUrl);
             if ($data !== false) {
                 $coverFile = $libraryPath . '/' . $bookPath . '/cover.jpg';

--- a/upload_book_file.php
+++ b/upload_book_file.php
@@ -13,10 +13,7 @@ function safe_filename(string $name, int $max_length = 150): string {
 }
 
 $pdo = getDatabaseConnection();
-$libraryPath = realpath(__DIR__ . '/ebooks');
-if ($libraryPath === false) {
-    $libraryPath = __DIR__ . '/ebooks';
-}
+$libraryPath = getLibraryPath();
 
 $bookId = isset($_GET['id']) ? (int)$_GET['id'] : (int)($_POST['id'] ?? 0);
 if ($bookId <= 0) {

--- a/users.json
+++ b/users.json
@@ -2,7 +2,8 @@
     "nilla": {
         "password": "nilla",
         "prefs": {
-            "db_path": "ebooks\/metadata.db"
+            "db_path": "ebooks\/metadata.db",
+            "library_path": "ebooks"
         }
     }
 }

--- a/view_book.php
+++ b/view_book.php
@@ -114,7 +114,7 @@ $missingFile = !bookHasFile($book['path']);
     <div class="row mb-4">
         <div class="col-md-3">
             <?php if (!empty($book['has_cover'])): ?>
-                <img src="ebooks/<?= htmlspecialchars($book['path']) ?>/cover.jpg" alt="Cover" class="img-fluid">
+                <img src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>" alt="Cover" class="img-fluid">
             <?php else: ?>
                 <div class="text-muted">No cover</div>
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- allow editing Calibre database and library paths
- fetch library path from user/global preferences
- reference library path instead of hard-coded `ebooks/`
- update default preferences

## Testing
- `php -l preferences.php`
- `php -l db.php`
- `php -l list_books.php`
- `php -l edit_book.php`
- `php -l reading_challenges.php`
- `php -l view_book.php`
- `php -l add_physical_book.php`
- `php -l upload_book_file.php`
- `php -l update_metadata.php`
- `php -l custom_column.php`

------
https://chatgpt.com/codex/tasks/task_e_68862a982cc08329ac864bd218680afd