### PR TITLE
Add metadata-only add-to-library buttons

### DIFF
--- a/add_metadata_book.php
+++ b/add_metadata_book.php
@@ -1,0 +1,97 @@
+<?php
+require_once 'db.php';
+requireLogin();
+
+function safe_filename(string $name, int $max_length = 150): string {
+    $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
+    return substr(trim($name), 0, $max_length);
+}
+
+$pdo = getDatabaseConnection();
+$libraryPath = getLibraryPath();
+
+$title = trim($_POST['title'] ?? '');
+$authors_str = trim($_POST['authors'] ?? '');
+$tags_str = trim($_POST['tags'] ?? '');
+
+if ($title === '' || $authors_str === '') {
+    http_response_code(400);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Title and authors are required.']);
+    exit;
+}
+
+try {
+    $pdo->beginTransaction();
+
+    $authors = array_map('trim', preg_split('/,|;/', $authors_str));
+    $firstAuthor = $authors[0];
+
+    foreach ($authors as $author) {
+        $stmt = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (?, author_sort(?))');
+        $stmt->execute([$author, $author]);
+    }
+
+    $tmpPath = safe_filename($title);
+    $stmt = $pdo->prepare(
+        'INSERT INTO books (title, sort, author_sort, timestamp, pubdate, series_index, last_modified, path, uuid)
+         VALUES (?, title_sort(?), author_sort(?), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1.0, CURRENT_TIMESTAMP, ?, uuid4())'
+    );
+    $stmt->execute([$title, $title, $firstAuthor, $tmpPath]);
+    $bookId = (int)$pdo->lastInsertId();
+
+    foreach ($authors as $author) {
+        $pdo->exec("INSERT INTO books_authors_link (book, author) SELECT $bookId, id FROM authors WHERE name=" . $pdo->quote($author));
+    }
+
+    $tags = [];
+    if ($tags_str !== '') {
+        $tags = array_map('trim', preg_split('/,|;/', $tags_str));
+        foreach ($tags as $tag) {
+            $pdo->exec("INSERT OR IGNORE INTO tags (name) VALUES (" . $pdo->quote($tag) . ")");
+            $pdo->exec("INSERT INTO books_tags_link (book, tag) SELECT $bookId, id FROM tags WHERE name=" . $pdo->quote($tag));
+        }
+    }
+
+    $authorFolderName = safe_filename($firstAuthor . (count($authors) > 1 ? ' et al.' : ''));
+    $bookFolderName = safe_filename($title) . " ($bookId)";
+    $bookPath = $authorFolderName . '/' . $bookFolderName;
+    $fullBookFolder = $libraryPath . '/' . $bookPath;
+
+    if (!is_dir(dirname($fullBookFolder))) {
+        mkdir(dirname($fullBookFolder), 0777, true);
+    }
+    if (!is_dir($fullBookFolder)) {
+        mkdir($fullBookFolder, 0777, true);
+    }
+
+    $pdo->prepare('UPDATE books SET path = ? WHERE id = ?')->execute([$bookPath, $bookId]);
+
+    $uuid = $pdo->query("SELECT uuid FROM books WHERE id = $bookId")->fetchColumn();
+
+    $tagsXml = '';
+    foreach ($tags as $tag) {
+        $tagsXml .= "    <dc:subject>" . htmlspecialchars($tag) . "</dc:subject>\n";
+    }
+
+    $timestamp = date('Y-m-d\TH:i:s');
+    $opf = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<package version=\"2.0\" xmlns=\"http://www.idpf.org/2007/opf\">\n  <metadata>\n" .
+           "    <dc:title>" . htmlspecialchars($title) . "</dc:title>\n" .
+           "    <dc:creator opf:role=\"aut\">" . htmlspecialchars($firstAuthor) . "</dc:creator>\n" .
+           $tagsXml .
+           "    <dc:language>eng</dc:language>\n" .
+           "    <dc:identifier opf:scheme=\"uuid\">$uuid</dc:identifier>\n" .
+           "    <meta name=\"calibre:timestamp\" content=\"$timestamp+00:00\"/>\n" .
+           "  </metadata>\n</package>";
+    file_put_contents($fullBookFolder . '/metadata.opf', $opf);
+
+    $pdo->commit();
+
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'ok', 'book_id' => $bookId]);
+} catch (Exception $e) {
+    $pdo->rollBack();
+    header('Content-Type: application/json');
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/annas_results.php
+++ b/annas_results.php
@@ -108,7 +108,7 @@ document.addEventListener('click', async (e) => {
         const resultEl = addBtn.parentElement.querySelector('.annas-add-result');
         if (resultEl) resultEl.textContent = 'Adding...';
         try {
-            const r = await fetch('add_book.php', {
+            const r = await fetch('add_metadata_book.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: new URLSearchParams({ title, authors })

--- a/google_results.php
+++ b/google_results.php
@@ -61,10 +61,48 @@ if ($search !== '') {
                         <p class="mb-0"><?= htmlspecialchars($book['description']) ?></p>
                     </div>
                 </div>
+                <div class="row mt-2">
+                    <div class="col-12">
+                        <button type="button" class="btn btn-sm btn-primary google-add"
+                                data-title="<?= htmlspecialchars($book['title'], ENT_QUOTES) ?>"
+                                data-authors="<?= htmlspecialchars($book['author'], ENT_QUOTES) ?>">
+                            Add to Library
+                        </button>
+                        <span class="google-add-result ms-1"></span>
+                    </div>
+                </div>
             </div>
         </div>
     <?php endforeach; ?>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+document.addEventListener('click', async (e) => {
+    const addBtn = e.target.closest('.google-add');
+    if (addBtn) {
+        const title = addBtn.dataset.title;
+        const authors = addBtn.dataset.authors;
+        const resultEl = addBtn.parentElement.querySelector('.google-add-result');
+        if (resultEl) resultEl.textContent = 'Adding...';
+        try {
+            const r = await fetch('add_metadata_book.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({ title, authors })
+            });
+            const data = await r.json();
+            if (resultEl) {
+                if (data.status === 'ok') {
+                    resultEl.textContent = 'Book added';
+                } else {
+                    resultEl.textContent = data.error || 'Error adding';
+                }
+            }
+        } catch (err) {
+            if (resultEl) resultEl.textContent = 'Error adding';
+        }
+    }
+});
+</script>
 </body>
 </html>

--- a/openlibrary_results.php
+++ b/openlibrary_results.php
@@ -62,12 +62,47 @@ if ($search !== '') {
                         &mdash;
                     <?php endif; ?>
                 </td>
-                <td>&mdash;</td>
+                <td>
+                    <button type="button" class="btn btn-sm btn-primary ol-add"
+                            data-title="<?= htmlspecialchars($book['title'], ENT_QUOTES) ?>"
+                            data-authors="<?= htmlspecialchars($book['authors'], ENT_QUOTES) ?>">
+                        Add to Library
+                    </button>
+                    <span class="ol-add-result ms-1"></span>
+                </td>
             </tr>
         <?php endforeach; ?>
         </tbody>
     </table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+document.addEventListener('click', async (e) => {
+    const addBtn = e.target.closest('.ol-add');
+    if (addBtn) {
+        const title = addBtn.dataset.title;
+        const authors = addBtn.dataset.authors;
+        const resultEl = addBtn.parentElement.querySelector('.ol-add-result');
+        if (resultEl) resultEl.textContent = 'Adding...';
+        try {
+            const r = await fetch('add_metadata_book.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({ title, authors })
+            });
+            const data = await r.json();
+            if (resultEl) {
+                if (data.status === 'ok') {
+                    resultEl.textContent = 'Book added';
+                } else {
+                    resultEl.textContent = data.error || 'Error adding';
+                }
+            }
+        } catch (err) {
+            if (resultEl) resultEl.textContent = 'Error adding';
+        }
+    }
+});
+</script>
 </body>
 </html>

--- a/openlibrary_view.php
+++ b/openlibrary_view.php
@@ -67,7 +67,7 @@ document.getElementById('addBtn').addEventListener('click', function () {
     const params = new URLSearchParams({title: title, authors: authors});
     const resultEl = document.getElementById('addResult');
     resultEl.textContent = 'Adding...';
-    fetch('add_book.php', {
+    fetch('add_metadata_book.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: params


### PR DESCRIPTION
## Summary
- implement `add_metadata_book.php` to add books without file uploads
- fix Anna's Archive result actions to call the new script
- add Add to Library buttons on Google Books results
- add Add to Library buttons on Open Library results
- update Open Library view page to use new endpoint

## Testing
- `php -l annas_results.php openlibrary_results.php google_results.php openlibrary_view.php add_metadata_book.php`

------
https://chatgpt.com/codex/tasks/task_e_68862f3646d483299b33126c0d816805