### PR TITLE
Add thumbnail and description when adding search result

### DIFF
--- a/add_metadata_book.php
+++ b/add_metadata_book.php
@@ -13,6 +13,8 @@ $libraryPath = getLibraryPath();
 $title = trim($_POST['title'] ?? '');
 $authors_str = trim($_POST['authors'] ?? '');
 $tags_str = trim($_POST['tags'] ?? '');
+$imgUrl = trim($_POST['imgurl'] ?? '');
+$description = trim($_POST['description'] ?? '');
 
 if ($title === '' || $authors_str === '') {
     http_response_code(400);
@@ -74,8 +76,8 @@ try {
         $tagsXml .= "    <dc:subject>" . htmlspecialchars($tag) . "</dc:subject>\n";
     }
 
-    $timestamp = date('Y-m-d\TH:i:s');
-    $opf = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<package version=\"2.0\" xmlns=\"http://www.idpf.org/2007/opf\">\n  <metadata>\n" .
+   $timestamp = date('Y-m-d\TH:i:s');
+   $opf = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<package version=\"2.0\" xmlns=\"http://www.idpf.org/2007/opf\">\n  <metadata>\n" .
            "    <dc:title>" . htmlspecialchars($title) . "</dc:title>\n" .
            "    <dc:creator opf:role=\"aut\">" . htmlspecialchars($firstAuthor) . "</dc:creator>\n" .
            $tagsXml .
@@ -83,7 +85,21 @@ try {
            "    <dc:identifier opf:scheme=\"uuid\">$uuid</dc:identifier>\n" .
            "    <meta name=\"calibre:timestamp\" content=\"$timestamp+00:00\"/>\n" .
            "  </metadata>\n</package>";
-    file_put_contents($fullBookFolder . '/metadata.opf', $opf);
+   file_put_contents($fullBookFolder . '/metadata.opf', $opf);
+
+    if ($imgUrl !== '') {
+        $data = @file_get_contents($imgUrl);
+        if ($data !== false) {
+            file_put_contents($fullBookFolder . '/cover.jpg', $data);
+            $pdo->prepare('UPDATE books SET has_cover = 1 WHERE id = ?')->execute([$bookId]);
+        }
+    }
+
+    if ($description !== '') {
+        $stmt = $pdo->prepare('INSERT INTO comments (book, text) VALUES (:book, :text) '
+            . 'ON CONFLICT(book) DO UPDATE SET text=excluded.text');
+        $stmt->execute([':book' => $bookId, ':text' => $description]);
+    }
 
     $pdo->commit();
 

--- a/annas_results.php
+++ b/annas_results.php
@@ -69,7 +69,9 @@ if ($search !== '') {
                     <?php endif; ?>
                     <button type="button" class="btn btn-sm btn-primary ms-1 annas-add"
                             data-title="<?= htmlspecialchars($book['title'], ENT_QUOTES) ?>"
-                            data-authors="<?= htmlspecialchars($book['author'], ENT_QUOTES) ?>">
+                            data-authors="<?= htmlspecialchars($book['author'], ENT_QUOTES) ?>"
+                            data-imgurl="<?= htmlspecialchars($book['imgUrl'], ENT_QUOTES) ?>"
+                            data-description="">
                         Add to Library
                     </button>
                     <span class="annas-add-result ms-1"></span>
@@ -105,13 +107,15 @@ document.addEventListener('click', async (e) => {
     if (addBtn) {
         const title = addBtn.dataset.title;
         const authors = addBtn.dataset.authors;
+        const imgurl = addBtn.dataset.imgurl || '';
+        const description = addBtn.dataset.description || '';
         const resultEl = addBtn.parentElement.querySelector('.annas-add-result');
         if (resultEl) resultEl.textContent = 'Adding...';
         try {
             const r = await fetch('add_metadata_book.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({ title, authors })
+                body: new URLSearchParams({ title, authors, imgurl, description })
             });
             const data = await r.json();
             if (resultEl) {

--- a/google_results.php
+++ b/google_results.php
@@ -65,7 +65,9 @@ if ($search !== '') {
                     <div class="col-12">
                         <button type="button" class="btn btn-sm btn-primary google-add"
                                 data-title="<?= htmlspecialchars($book['title'], ENT_QUOTES) ?>"
-                                data-authors="<?= htmlspecialchars($book['author'], ENT_QUOTES) ?>">
+                                data-authors="<?= htmlspecialchars($book['author'], ENT_QUOTES) ?>"
+                                data-imgurl="<?= htmlspecialchars($book['imgUrl'], ENT_QUOTES) ?>"
+                                data-description="<?= htmlspecialchars($book['description'], ENT_QUOTES) ?>">
                             Add to Library
                         </button>
                         <span class="google-add-result ms-1"></span>
@@ -82,13 +84,15 @@ document.addEventListener('click', async (e) => {
     if (addBtn) {
         const title = addBtn.dataset.title;
         const authors = addBtn.dataset.authors;
+        const imgurl = addBtn.dataset.imgurl || '';
+        const description = addBtn.dataset.description || '';
         const resultEl = addBtn.parentElement.querySelector('.google-add-result');
         if (resultEl) resultEl.textContent = 'Adding...';
         try {
             const r = await fetch('add_metadata_book.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({ title, authors })
+                body: new URLSearchParams({ title, authors, imgurl, description })
             });
             const data = await r.json();
             if (resultEl) {

--- a/openlibrary_results.php
+++ b/openlibrary_results.php
@@ -65,7 +65,9 @@ if ($search !== '') {
                 <td>
                     <button type="button" class="btn btn-sm btn-primary ol-add"
                             data-title="<?= htmlspecialchars($book['title'], ENT_QUOTES) ?>"
-                            data-authors="<?= htmlspecialchars($book['authors'], ENT_QUOTES) ?>">
+                            data-authors="<?= htmlspecialchars($book['authors'], ENT_QUOTES) ?>"
+                            data-imgurl="<?= htmlspecialchars(!empty($book['cover_id']) ? 'https://covers.openlibrary.org/b/id/' . $book['cover_id'] . '-L.jpg' : '', ENT_QUOTES) ?>"
+                            data-description="">
                         Add to Library
                     </button>
                     <span class="ol-add-result ms-1"></span>
@@ -82,13 +84,15 @@ document.addEventListener('click', async (e) => {
     if (addBtn) {
         const title = addBtn.dataset.title;
         const authors = addBtn.dataset.authors;
+        const imgurl = addBtn.dataset.imgurl || '';
+        const description = addBtn.dataset.description || '';
         const resultEl = addBtn.parentElement.querySelector('.ol-add-result');
         if (resultEl) resultEl.textContent = 'Adding...';
         try {
             const r = await fetch('add_metadata_book.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: new URLSearchParams({ title, authors })
+                body: new URLSearchParams({ title, authors, imgurl, description })
             });
             const data = await r.json();
             if (resultEl) {

--- a/openlibrary_view.php
+++ b/openlibrary_view.php
@@ -52,7 +52,9 @@ if (!$coverId && !empty($covers)) {
             <?php endif; ?>
             <button id="addBtn" type="button" class="btn btn-primary mt-3"
                     data-title="<?= htmlspecialchars($workTitle, ENT_QUOTES) ?>"
-                    data-authors="<?= htmlspecialchars($authors, ENT_QUOTES) ?>">
+                    data-authors="<?= htmlspecialchars($authors, ENT_QUOTES) ?>"
+                    data-imgurl="<?= htmlspecialchars($coverId ? 'https://covers.openlibrary.org/b/id/' . $coverId . '-L.jpg' : '', ENT_QUOTES) ?>"
+                    data-description="<?= htmlspecialchars($description, ENT_QUOTES) ?>">
                 Add to Library
             </button>
             <div id="addResult" class="mt-2"></div>
@@ -64,7 +66,9 @@ if (!$coverId && !empty($covers)) {
 document.getElementById('addBtn').addEventListener('click', function () {
     const title = this.dataset.title;
     const authors = this.dataset.authors;
-    const params = new URLSearchParams({title: title, authors: authors});
+    const imgurl = this.dataset.imgurl || '';
+    const description = this.dataset.description || '';
+    const params = new URLSearchParams({title: title, authors: authors, imgurl: imgurl, description: description});
     const resultEl = document.getElementById('addResult');
     resultEl.textContent = 'Adding...';
     fetch('add_metadata_book.php', {


### PR DESCRIPTION
## Summary
- extend Add to Library buttons on all search result pages to include thumbnail and description fields
- support new parameters in `add_metadata_book.php`

## Testing
- `php -l google_results.php`
- `php -l openlibrary_results.php`
- `php -l annas_results.php`
- `php -l openlibrary_view.php`
- `php -l add_metadata_book.php`


------
https://chatgpt.com/codex/tasks/task_e_688631cf16888329a0f57c3b6249719d