### PR TITLE
Fix nav search on results pages

### DIFF
--- a/annas_results.php
+++ b/annas_results.php
@@ -19,6 +19,7 @@ if ($search !== '') {
     <title>Anna's Archive Results</title>
     <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <script src="theme.js"></script>
+    <script src="navbar_search.js"></script>
 </head>
 <body class="pt-5">
 <?php include "navbar.php"; ?>

--- a/google_results.php
+++ b/google_results.php
@@ -19,6 +19,7 @@ if ($search !== '') {
     <title>Google Books Results</title>
     <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <script src="theme.js"></script>
+    <script src="navbar_search.js"></script>
 </head>
 <body class="pt-5">
 <?php include "navbar.php"; ?>

--- a/list_books.php
+++ b/list_books.php
@@ -493,6 +493,7 @@ function linkTextColor(string $current, string $compare): string {
     <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous">
     <script src="theme.js"></script>
+    <script src="navbar_search.js"></script>
     <!-- Removed jQuery and jQuery UI -->
     <style>
         .title-col {
@@ -746,27 +747,7 @@ function escapeHTML(str) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const searchInput = document.querySelector('input[name="search"]');
-    const suggestionList = document.getElementById('authorSuggestions');
-    if (searchInput && suggestionList) {
-        searchInput.addEventListener('input', async () => {
-            const term = searchInput.value.trim();
-            suggestionList.innerHTML = '';
-            if (term.length < 2) return;
-            try {
-                const res = await fetch(`author_autocomplete.php?term=${encodeURIComponent(term)}`);
-                const data = await res.json();
-                suggestionList.innerHTML = '';
-                data.forEach(name => {
-                    const opt = document.createElement('option');
-                    opt.value = name;
-                    suggestionList.appendChild(opt);
-                });
-            } catch (err) {
-                console.error(err);
-            }
-        });
-    }
+
 
     var currentPage = <?= $page ?>;
     var totalPages = <?= $totalPages ?>;

--- a/navbar_search.js
+++ b/navbar_search.js
@@ -1,0 +1,30 @@
+(function(){
+  function initAutocomplete(){
+    const searchInput = document.querySelector('input[name="search"]');
+    const suggestionList = document.getElementById('authorSuggestions');
+    if (!searchInput || !suggestionList) return;
+    searchInput.addEventListener('input', async () => {
+      const term = searchInput.value.trim();
+      suggestionList.innerHTML = '';
+      if (term.length < 2) return;
+      try {
+        const res = await fetch(`author_autocomplete.php?term=${encodeURIComponent(term)}`);
+        const data = await res.json();
+        suggestionList.innerHTML = '';
+        data.forEach(name => {
+          const opt = document.createElement('option');
+          opt.value = name;
+          suggestionList.appendChild(opt);
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAutocomplete);
+  } else {
+    initAutocomplete();
+  }
+})();

--- a/openlibrary_results.php
+++ b/openlibrary_results.php
@@ -19,6 +19,7 @@ if ($search !== '') {
     <title>Open Library Results</title>
     <link id="themeStylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <script src="theme.js"></script>
+    <script src="navbar_search.js"></script>
 </head>
 <body class="pt-5">
 <?php include "navbar.php"; ?>


### PR DESCRIPTION
## Summary
- factor nav search autocomplete into `navbar_search.js`
- load new script on `list_books.php` and external results pages
- remove duplicated search logic from `list_books.php`

## Testing
- `php -l openlibrary_results.php`
- `php -l google_results.php`
- `php -l annas_results.php`
- `php -l list_books.php`

------
https://chatgpt.com/codex/tasks/task_e_688635a03a5083299f24efafb161c5b4