### PR TITLE
Redirect to list page after adding a book

### DIFF
--- a/annas_results.php
+++ b/annas_results.php
@@ -119,12 +119,15 @@ document.addEventListener('click', async (e) => {
                 body: new URLSearchParams({ title, authors, thumbnail, description })
             });
             const data = await r.json();
+            if (data.status === 'ok') {
+                window.location.href =
+                    'list_books.php?search=' +
+                    encodeURIComponent(title) +
+                    '&source=local';
+                return;
+            }
             if (resultEl) {
-                if (data.status === 'ok') {
-                    resultEl.textContent = 'Book added';
-                } else {
-                    resultEl.textContent = data.error || 'Error adding';
-                }
+                resultEl.textContent = data.error || 'Error adding';
             }
         } catch (err) {
             if (resultEl) resultEl.textContent = 'Error adding';

--- a/google_results.php
+++ b/google_results.php
@@ -96,12 +96,15 @@ document.addEventListener('click', async (e) => {
                 body: new URLSearchParams({ title, authors, thumbnail, description })
             });
             const data = await r.json();
+            if (data.status === 'ok') {
+                window.location.href =
+                    'list_books.php?search=' +
+                    encodeURIComponent(title) +
+                    '&source=local';
+                return;
+            }
             if (resultEl) {
-                if (data.status === 'ok') {
-                    resultEl.textContent = 'Book added';
-                } else {
-                    resultEl.textContent = data.error || 'Error adding';
-                }
+                resultEl.textContent = data.error || 'Error adding';
             }
         } catch (err) {
             if (resultEl) resultEl.textContent = 'Error adding';

--- a/openlibrary_results.php
+++ b/openlibrary_results.php
@@ -117,12 +117,15 @@ document.addEventListener('click', async (e) => {
                 body: new URLSearchParams({ title, authors, thumbnail, description })
             });
             const data = await r.json();
+            if (data.status === 'ok') {
+                window.location.href =
+                    'list_books.php?search=' +
+                    encodeURIComponent(title) +
+                    '&source=local';
+                return;
+            }
             if (resultEl) {
-                if (data.status === 'ok') {
-                    resultEl.textContent = 'Book added';
-                } else {
-                    resultEl.textContent = data.error || 'Error adding';
-                }
+                resultEl.textContent = data.error || 'Error adding';
             }
         } catch (err) {
             if (resultEl) resultEl.textContent = 'Error adding';

--- a/openlibrary_view.php
+++ b/openlibrary_view.php
@@ -80,10 +80,13 @@ document.getElementById('addBtn').addEventListener('click', function () {
     .then(resp => resp.json())
     .then(data => {
         if (data.status === 'ok') {
-            resultEl.textContent = 'Book added to library';
-        } else {
-            resultEl.textContent = data.error || 'Error adding book';
+            window.location.href =
+                'list_books.php?search=' +
+                encodeURIComponent(title) +
+                '&source=local';
+            return;
         }
+        resultEl.textContent = data.error || 'Error adding book';
     })
     .catch(() => {
         resultEl.textContent = 'Error adding book';


### PR DESCRIPTION
## Summary
- redirect from "Add to Library" buttons to `list_books.php` when a book is successfully added

## Testing
- `php -l openlibrary_results.php`
- `php -l google_results.php`
- `php -l annas_results.php`
- `php -l openlibrary_view.php`
- `php -l add_metadata_book.php`


------
https://chatgpt.com/codex/tasks/task_e_68863aeadc188329875bd9940be6dcd2