### PR TITLE
Limit Open Library results

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ inserts the metadata into the database, similar to Calibre's "Add Book" feature.
 
 ## Searching
 
-Use the search bar at the top of `list_books.php` to search for books by title or author name. A dropdown next to the search field lets you choose between searching the **local** Calibre database, querying the **Open Library** API, searching **Google Books**, or searching **Anna's Archive**. Results from external sources are shown in the same table layout but without local-only actions.
+Use the search bar at the top of `list_books.php` to search for books by title or author name. A dropdown next to the search field lets you choose between searching the **local** Calibre database, querying the **Open Library** API, searching **Google Books**, or searching **Anna's Archive**. Results from external sources are shown in the same table layout but without local-only actions. Open Library searches return only the first five matches to avoid excessive API requests.
 
 When viewing a book you can click **Get Book Recommendations**. The returned text is parsed to identify
 the recommended title and author. Each title links back to `list_books.php` with an Open Library search

--- a/openlibrary.php
+++ b/openlibrary.php
@@ -16,14 +16,14 @@ function fetch_openlibrary_json(string $url): ?array {
     return is_array($data) ? $data : null;
 }
 
-function search_openlibrary(string $query): array {
-    $url = 'https://openlibrary.org/search.json?q=' . urlencode($query);
+function search_openlibrary(string $query, int $limit = 5): array {
+    $url = 'https://openlibrary.org/search.json?q=' . urlencode($query) . '&limit=' . $limit;
     $data = fetch_openlibrary_json($url);
     if ($data === null || !isset($data['docs'])) {
         return [];
     }
     $results = [];
-    foreach ($data['docs'] as $doc) {
+    foreach (array_slice($data['docs'], 0, $limit) as $doc) {
         $results[] = [
             'title' => $doc['title'] ?? '',
             'authors' => isset($doc['author_name']) ? implode(', ', (array)$doc['author_name']) : '',


### PR DESCRIPTION
## Summary
- trim down Open Library responses to just 5 results
- update docs about the Open Library search limit

## Testing
- `php -l openlibrary.php`
- `php -l openlibrary_search.php`
- `php -l openlibrary_results.php`
- `php -l openlibrary_view.php`

------
https://chatgpt.com/codex/tasks/task_e_68863d5f2634832981f55d00b343e798