### PR TITLE
Refactor single-value columns

### DIFF
--- a/add_book.php
+++ b/add_book.php
@@ -40,9 +40,11 @@ try {
 
     // Assign default shelf
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $shelfTable = "custom_column_{$shelfId}";
-    $stmt = $pdo->prepare("INSERT OR IGNORE INTO $shelfTable (book, value) VALUES (:book, :val)");
-    $stmt->execute([':book' => $bookId, ':val' => 'Ebook Calibre']);
+    $shelfValueTable = "custom_column_{$shelfId}";
+    $shelfLinkTable  = "books_custom_column_{$shelfId}_link";
+    $pdo->prepare("INSERT OR IGNORE INTO $shelfValueTable (value) VALUES ('Ebook Calibre')")->execute();
+    $valId = $pdo->query("SELECT id FROM $shelfValueTable WHERE value = 'Ebook Calibre'")->fetchColumn();
+    $pdo->prepare("INSERT INTO $shelfLinkTable (book, value) VALUES (:book, :val)")->execute([':book' => $bookId, ':val' => $valId]);
 
     // Assign default status
     $statusId = ensureMultiValueColumn($pdo, '#status', 'Status');

--- a/book.php
+++ b/book.php
@@ -98,8 +98,9 @@ $tags = $tagsStmt->fetchColumn();
 // Fetch saved recommendations if present
 try {
     $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-    $table = "custom_column_{$recId}";
-    $recStmt = $pdo->prepare("SELECT value FROM $table WHERE book = ?");
+    $valueTable = "custom_column_{$recId}";
+    $linkTable  = "books_custom_column_{$recId}_link";
+    $recStmt = $pdo->prepare("SELECT v.value FROM $linkTable l JOIN $valueTable v ON l.value = v.id WHERE l.book = ? LIMIT 1");
     $recStmt->execute([$id]);
     $savedRecommendations = $recStmt->fetchColumn();
 } catch (PDOException $e) {

--- a/db.php
+++ b/db.php
@@ -229,8 +229,9 @@ function ensureSingleValueColumn(PDO $pdo, string $label, string $name = null): 
         $id = $pdo->lastInsertId();
     }
 
-    $table = "custom_column_$id";
-    ensureSingleValueTable($pdo, $table);
+    $valueTable = "custom_column_$id";
+    $linkTable  = "books_custom_column_{$id}_link";
+    ensureSingleValueTable($pdo, $valueTable, $linkTable);
 
     return (int)$id;
 }
@@ -261,10 +262,23 @@ function ensureMultiValueColumn(PDO $pdo, string $label, string $name = null): i
 
 function insertDefaultSingleValue(PDO $pdo, int $columnId, string $defaultValue): void {
     $valueTable = "custom_column_$columnId";
+    $linkTable  = "books_custom_column_{$columnId}_link";
 
-    // Assign default value to books that do not yet have an entry
-    $stmt = $pdo->prepare("INSERT OR IGNORE INTO $valueTable (book, value) SELECT id, ? FROM books WHERE id NOT IN (SELECT book FROM $valueTable)");
+    // Ensure default value exists
+    $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (?)")
+        ->execute([$defaultValue]);
+
+    // Get the ID of the default value
+    $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = ?");
     $stmt->execute([$defaultValue]);
+    $valueId = $stmt->fetchColumn();
+
+    // Assign default value to books without any entry
+    $pdo->exec(
+        "INSERT INTO $linkTable (book, value)
+         SELECT id, $valueId FROM books
+         WHERE id NOT IN (SELECT book FROM $linkTable)"
+    );
 }
 
 function insertDefaultMultiValue(PDO $pdo, int $columnId, string $defaultValue): void {
@@ -304,39 +318,43 @@ function tableColumns(PDO $pdo, string $table): array {
     return $cols;
 }
 
-function ensureSingleValueTable(PDO $pdo, string $table): void {
-    $expected = ['book', 'value'];
+function ensureSingleValueTable(PDO $pdo, string $valueTable, string $linkTable): void {
+    $expectedOld = ['book', 'value'];
+    $expectedNew = ['id', 'value', 'link'];
 
-    if (tableExists($pdo, $table)) {
-        $cols = tableColumns($pdo, $table);
+    $needsMigration = false;
+    if (tableExists($pdo, $valueTable)) {
+        $cols = tableColumns($pdo, $valueTable);
         $sorted = $cols;
         sort($sorted);
-        $exp = $expected;
-        sort($exp);
-        if ($sorted === $exp) {
-            return;
+        $expOld = $expectedOld;
+        sort($expOld);
+        $expNew = $expectedNew;
+        sort($expNew);
+        if ($sorted === $expOld) {
+            $backup = $valueTable . '_backup_' . time();
+            $pdo->exec("ALTER TABLE $valueTable RENAME TO $backup");
+            $needsMigration = $backup;
+        } elseif ($sorted === $expNew) {
+            // Already in new format
+            $backup = null;
+        } else {
+            $backup = $valueTable . '_backup_' . time();
+            $pdo->exec("ALTER TABLE $valueTable RENAME TO $backup");
+            $needsMigration = $backup;
         }
-
-        $backup = $table . '_backup_' . time();
-        $pdo->exec("ALTER TABLE $table RENAME TO $backup");
     } else {
         $backup = null;
     }
 
-    $pdo->exec(
-        "CREATE TABLE $table (
-            book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE,
-            value TEXT
-        )"
-    );
+    ensureMultiValueTables($pdo, $valueTable, $linkTable);
 
-    if ($backup) {
-        $cols = tableColumns($pdo, $backup);
-        $common = array_intersect($cols, $expected);
-        if ($common) {
-            $colList = implode(',', $common);
-            $pdo->exec("INSERT INTO $table ($colList) SELECT $colList FROM $backup");
-        }
+    if ($needsMigration) {
+        $pdo->exec("INSERT OR IGNORE INTO $valueTable (value) SELECT DISTINCT value FROM $needsMigration");
+        $pdo->exec(
+            "INSERT INTO $linkTable (book, value) " .
+            "SELECT b.book, v.id FROM $needsMigration b JOIN $valueTable v ON v.value = b.value"
+        );
     }
 }
 

--- a/list_books.php
+++ b/list_books.php
@@ -14,10 +14,13 @@ try {
     }
 
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $shelfTable = "custom_column_{$shelfId}";
-    $pdo->exec("INSERT OR IGNORE INTO $shelfTable (book, value)
-            SELECT id, 'Ebook Calibre' FROM books
-            WHERE id NOT IN (SELECT book FROM $shelfTable)");
+    $shelfValueTable = "custom_column_{$shelfId}";
+    $shelfLinkTable  = "books_custom_column_{$shelfId}_link";
+    $pdo->prepare("INSERT OR IGNORE INTO $shelfValueTable (value) VALUES ('Ebook Calibre')")->execute();
+    $valId = $pdo->query("SELECT id FROM $shelfValueTable WHERE value = 'Ebook Calibre'")->fetchColumn();
+    $pdo->exec("INSERT INTO $shelfLinkTable (book, value)
+            SELECT id, $valId FROM books
+            WHERE id NOT IN (SELECT book FROM $shelfLinkTable)");
 } catch (PDOException $e) {
     // Ignore errors if the table cannot be created
 }
@@ -58,14 +61,18 @@ try {
 // Ensure shelf column exists for recommendations block
 try {
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $shelfTable = "custom_column_{$shelfId}";
-    $pdo->exec("INSERT OR IGNORE INTO $shelfTable (book, value)\n            SELECT id, 'Ebook Calibre' FROM books\n            WHERE id NOT IN (SELECT book FROM $shelfTable)");
+    $shelfValueTable = "custom_column_{$shelfId}";
+    $shelfLinkTable  = "books_custom_column_{$shelfId}_link";
+    $pdo->prepare("INSERT OR IGNORE INTO $shelfValueTable (value) VALUES ('Ebook Calibre')")->execute();
+    $valId = $pdo->query("SELECT id FROM $shelfValueTable WHERE value = 'Ebook Calibre'")->fetchColumn();
+    $pdo->exec("INSERT INTO $shelfLinkTable (book, value)\n            SELECT id, $valId FROM books\n            WHERE id NOT IN (SELECT book FROM $shelfLinkTable)");
 } catch (PDOException $e) {
     // Ignore errors if the table cannot be created
 }
 
 $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-$recTable = "custom_column_{$recId}";
+$recValueTable = "custom_column_{$recId}";
+$recTable = "books_custom_column_{$recId}_link";
 $recColumnExists = true;
 
 $perPage = 20;
@@ -123,7 +130,7 @@ if ($genreName !== '') {
     $params[':genre_val'] = $genreName;
 }
 if ($shelfName !== '') {
-    $whereClauses[] = 'b.id IN (SELECT book FROM ' . $shelfTable . ' WHERE value = :shelf_name)';
+    $whereClauses[] = 'EXISTS (SELECT 1 FROM ' . $shelfLinkTable . ' sl JOIN ' . $shelfValueTable . ' sv ON sl.value = sv.id WHERE sl.book = b.id AND sv.value = :shelf_name)';
     $params[':shelf_name'] = $shelfName;
 }
 if ($statusName !== '' && $statusTable) {
@@ -143,7 +150,7 @@ if ($statusName !== '' && $statusTable) {
     }
 }
 if ($recommendedOnly) {
-    $whereClauses[] = "EXISTS (SELECT 1 FROM $recTable WHERE book = b.id AND TRIM(COALESCE(value, '')) <> '')";
+    $whereClauses[] = "EXISTS (SELECT 1 FROM $recTable rl JOIN $recValueTable rv ON rl.value = rv.id WHERE rl.book = b.id AND TRIM(COALESCE(rv.value, '')) <> '')";
 }
 if ($search !== '') {
     $whereClauses[] = '(b.title LIKE :search OR EXISTS (
@@ -212,7 +219,7 @@ $books = [];
                             FROM $genreLinkTable bcc
                             JOIN custom_column_{$genreColumnId} gv ON bcc.value = gv.id
                             WHERE bcc.book = b.id) AS genre_data,
-                       bc11.value AS shelf,
+                       bc11v.value AS shelf,
                        com.text AS description";
         if ($statusTable) {
             if ($statusIsLink) {
@@ -222,14 +229,15 @@ $books = [];
             }
         }
         if ($recColumnExists) {
-            $selectFields .= ", EXISTS(SELECT 1 FROM $recTable WHERE book = b.id AND TRIM(COALESCE(value, '')) <> '') AS has_recs";
+            $selectFields .= ", EXISTS(SELECT 1 FROM $recTable rl JOIN $recValueTable rv ON rl.value = rv.id WHERE rl.book = b.id AND TRIM(COALESCE(rv.value, '')) <> '') AS has_recs";
         }
 
         $sql = "SELECT $selectFields
                 FROM books b
                 LEFT JOIN books_series_link bsl ON bsl.book = b.id
                 LEFT JOIN series s ON bsl.series = s.id
-                LEFT JOIN $shelfTable bc11 ON bc11.book = b.id
+                LEFT JOIN $shelfLinkTable bc11 ON bc11.book = b.id
+                LEFT JOIN $shelfValueTable bc11v ON bc11.value = bc11v.id
                 LEFT JOIN comments com ON com.book = b.id";
         if ($statusTable) {
             if ($statusIsLink) {

--- a/recommend.php
+++ b/recommend.php
@@ -24,9 +24,16 @@ try {
         $pdo = getDatabaseConnection();
 
         $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-        $table = "custom_column_{$recId}";
-        $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
-        $stmt->execute([':book' => $bookId, ':val' => $output]);
+        $valueTable = "custom_column_{$recId}";
+        $linkTable  = "books_custom_column_{$recId}_link";
+        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+            ->execute([':val' => $output]);
+        $valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+        $valStmt->execute([':val' => $output]);
+        $valId = $valStmt->fetchColumn();
+        $pdo->prepare("DELETE FROM $linkTable WHERE book = :book")->execute([':book' => $bookId]);
+        $stmt = $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :val)");
+        $stmt->execute([':book' => $bookId, ':val' => $valId]);
     }
 
     echo json_encode(['output' => $output]);

--- a/update_shelf.php
+++ b/update_shelf.php
@@ -21,10 +21,19 @@ if ($bookId <= 0 || !in_array($value, $allowed, true)) {
 }
 
 $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-$table = "custom_column_{$shelfId}";
+$valueTable = "custom_column_{$shelfId}";
+$linkTable  = "books_custom_column_{$shelfId}_link";
 
-$stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
-$stmt->execute([':book' => $bookId, ':val' => $value]);
+$pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+    ->execute([':val' => $value]);
+$valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+$valStmt->execute([':val' => $value]);
+$valId = $valStmt->fetchColumn();
+
+$pdo->prepare("DELETE FROM $linkTable WHERE book = :book")
+    ->execute([':book' => $bookId]);
+$stmt = $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :val)");
+$stmt->execute([':book' => $bookId, ':val' => $valId]);
 
 echo json_encode(['status' => 'ok']);
 ?>

--- a/view_book.php
+++ b/view_book.php
@@ -47,8 +47,9 @@ $tags = $tagsStmt->fetchColumn();
 // Fetch saved recommendations from custom column, if present
 try {
     $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-    $table = "custom_column_{$recId}";
-    $recStmt = $pdo->prepare("SELECT value FROM $table WHERE book = ?");
+    $valueTable = "custom_column_{$recId}";
+    $linkTable  = "books_custom_column_{$recId}_link";
+    $recStmt = $pdo->prepare("SELECT v.value FROM $linkTable l JOIN $valueTable v ON l.value = v.id WHERE l.book = ? LIMIT 1");
     $recStmt->execute([$id]);
     $savedRecommendations = $recStmt->fetchColumn();
 } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- migrate single-value custom columns to Calibre-style tables
- update shelf and recommendation scripts for new tables
- use link tables when retrieving saved recommendations
- update book list queries for new shelf/recommendation structure

## Testing
- `php -l db.php`
- `php -l add_book.php`
- `php -l update_shelf.php`
- `php -l delete_shelf.php`
- `php -l recommend.php`
- `php -l book.php`
- `php -l view_book.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_68875b1e11808329a21b1b94d6021e7c