### PR TITLE
Ensure tag browser views for custom columns

### DIFF
--- a/add_col.sh
+++ b/add_col.sh
@@ -14,6 +14,42 @@ sqlite3 "$DB" "INSERT INTO custom_columns (id, label, name, datatype, mark_for_d
 sqlite3 "$DB" "CREATE TABLE custom_column_${NEXT_ID} (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value));"
 sqlite3 "$DB" "CREATE TABLE books_custom_column_${NEXT_ID}_link (id INTEGER PRIMARY KEY AUTOINCREMENT, book INTEGER NOT NULL, value INTEGER NOT NULL, UNIQUE(book, value));"
 
+# Create the tag browser views if they don't already exist
+sqlite3 "$DB" "CREATE VIEW IF NOT EXISTS tag_browser_custom_column_${NEXT_ID} AS
+    SELECT
+        id,
+        value,
+        (SELECT COUNT(id) FROM books_custom_column_${NEXT_ID}_link WHERE value=custom_column_${NEXT_ID}.id) count,
+        (SELECT AVG(r.rating)
+            FROM books_custom_column_${NEXT_ID}_link,
+                 books_ratings_link AS bl,
+                 ratings AS r
+            WHERE books_custom_column_${NEXT_ID}_link.value=custom_column_${NEXT_ID}.id
+              AND bl.book=books_custom_column_${NEXT_ID}_link.book
+              AND r.id = bl.rating
+              AND r.rating <> 0) avg_rating,
+        value AS sort
+    FROM custom_column_${NEXT_ID};"
+
+sqlite3 "$DB" "CREATE VIEW IF NOT EXISTS tag_browser_filtered_custom_column_${NEXT_ID} AS
+    SELECT
+        id,
+        value,
+        (SELECT COUNT(books_custom_column_${NEXT_ID}_link.id)
+         FROM books_custom_column_${NEXT_ID}_link
+         WHERE value=custom_column_${NEXT_ID}.id AND books_list_filter(book)) count,
+        (SELECT AVG(r.rating)
+            FROM books_custom_column_${NEXT_ID}_link,
+                 books_ratings_link AS bl,
+                 ratings AS r
+            WHERE books_custom_column_${NEXT_ID}_link.value=custom_column_${NEXT_ID}.id
+              AND bl.book=books_custom_column_${NEXT_ID}_link.book
+              AND r.id = bl.rating
+              AND r.rating <> 0
+              AND books_list_filter(bl.book)) avg_rating,
+        value AS sort
+    FROM custom_column_${NEXT_ID};"
+
 # Populate default NULL entry for existing books
 sqlite3 "$DB" "INSERT INTO books_custom_column_${NEXT_ID}_link (book, value) SELECT id, NULL FROM books;"
 


### PR DESCRIPTION
## Summary
- add `viewExists()` and `ensureCustomColumnViews()` in `db.php`
- create tag browser views when adding a custom column
- create equivalent views in `add_col.sh`

## Testing
- `php -l db.php`
- `shellcheck add_col.sh`


------
https://chatgpt.com/codex/tasks/task_e_688760256cf48329b89a1077eec68a5b