### PR TITLE
Align custom column setup with Calibre

### DIFF
--- a/add_col.sh
+++ b/add_col.sh
@@ -8,7 +8,7 @@ DB=$(php -r "require 'db.php'; echo currentDatabasePath();")
 NEXT_ID=$(sqlite3 "$DB" "SELECT COALESCE(MAX(id), 0) + 1 FROM custom_columns;")
 
 # Insert into custom_columns (no search_terms column)
-sqlite3 "$DB" "INSERT INTO custom_columns (id, label, name, datatype, mark_for_delete, editable, is_multiple, normalized, display) VALUES ($NEXT_ID, 'shelfs', 'myshelf', 'text', 0, 1, 0, 1, '{}');"
+sqlite3 "$DB" "INSERT INTO custom_columns (id, label, name, datatype, is_multiple, editable, display, normalized) VALUES ($NEXT_ID, 'shelfs', 'myshelf', 'text', 0, 1, '{}', 1);"
 
 # Create the value and link tables for the new column
 sqlite3 "$DB" "CREATE TABLE custom_column_${NEXT_ID} (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL COLLATE NOCASE, link TEXT NOT NULL DEFAULT '', UNIQUE(value));"

--- a/custom_column.php
+++ b/custom_column.php
@@ -5,8 +5,8 @@ $pdo = new PDO('sqlite:' . getLibraryPath() . '/metadata.db');
 // Create single-value column: shelf
 $pdo->exec("
     INSERT INTO custom_columns
-    (label, name, datatype, mark_for_delete, editable, display, is_multiple, normalized)
-    VALUES ('shelf', 'Shelf', 'text', 0, 1, '{}', 0, 0)
+    (label, name, datatype, is_multiple, editable, display, normalized)
+    VALUES ('shelf', 'Shelf', 'text', 0, 1, '{}', 0)
 ");
 $shelfId = $pdo->lastInsertId();
 
@@ -21,8 +21,8 @@ $pdo->exec("
 // Create multi-value custom column: #genre
 $pdo->exec("
     INSERT INTO custom_columns
-    (label, name, datatype, mark_for_delete, editable, display, is_multiple, normalized)
-    VALUES ('#genre', 'Genre', 'text', 0, 1, '{}', 1, 1)
+    (label, name, datatype, is_multiple, editable, display, normalized)
+    VALUES ('#genre', 'Genre', 'text', 1, 1, '{}', 1)
 ");
 $genreId = $pdo->lastInsertId();
 

--- a/db.php
+++ b/db.php
@@ -192,6 +192,8 @@ function initializeCustomColumns(PDO $pdo): void {
             $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$def]);
         }
 
+        ensureCustomColumnsIndex($pdo);
+
         // 2. Ensure Shelf column (single-value)
         $shelfId = ensureSingleValueColumn($pdo, 'shelf', 'Shelf');
         insertDefaultSingleValue($pdo, $shelfId, 'Ebook Calibre');
@@ -223,8 +225,8 @@ function ensureSingleValueColumn(PDO $pdo, string $label, string $name = null): 
     if ($id === false) {
         $pdo->prepare(
             "INSERT INTO custom_columns
-            (label, name, datatype, mark_for_delete, editable, display, is_multiple, normalized)
-            VALUES (?, ?, 'text', 0, 1, '{}', 0, 0)"
+            (label, name, datatype, is_multiple, editable, display, normalized)
+            VALUES (?, ?, 'text', 0, 1, '{}', 0)"
         )->execute([$label, $name]);
         $id = $pdo->lastInsertId();
     }
@@ -248,8 +250,8 @@ function ensureMultiValueColumn(PDO $pdo, string $label, string $name = null): i
     if ($id === false) {
         $pdo->prepare(
             "INSERT INTO custom_columns
-            (label, name, datatype, mark_for_delete, editable, display, is_multiple, normalized)
-            VALUES (?, ?, 'text', 0, 1, '{}', 1, 1)"
+            (label, name, datatype, is_multiple, editable, display, normalized)
+            VALUES (?, ?, 'text', 1, 1, '{}', 1)"
         )->execute([$label, $name]);
         $id = $pdo->lastInsertId();
     }
@@ -473,7 +475,7 @@ function ensureCustomColumnExtras(PDO $pdo, int $id): void {
     $pdo->exec("DROP TRIGGER IF EXISTS fkc_update_{$linkTable}_b");
     $pdo->exec(
         "CREATE TRIGGER fkc_update_{$linkTable}_b " .
-        "BEFORE UPDATE OF author ON $linkTable " .
+        "BEFORE UPDATE OF value ON $linkTable " .
         "BEGIN " .
             "SELECT CASE WHEN (SELECT id FROM $valueTable WHERE id=NEW.value) IS NULL " .
                 "THEN RAISE(ABORT, 'Foreign key violation: value not in $valueTable') END;" .
@@ -537,4 +539,8 @@ function ensureCustomColumnViews(PDO $pdo, int $id): void {
             "value AS sort FROM custom_column_{$id}"
         );
     }
+}
+
+function ensureCustomColumnsIndex(PDO $pdo): void {
+    $pdo->exec("CREATE INDEX IF NOT EXISTS custom_columns_idx ON custom_columns (label)");
 }

--- a/schema.sql
+++ b/schema.sql
@@ -670,7 +670,7 @@ CREATE TRIGGER fkc_update_books_custom_column_1_link_a
                             END;
                         END;
 CREATE TRIGGER fkc_update_books_custom_column_1_link_b
-                        BEFORE UPDATE OF author ON books_custom_column_1_link
+                        BEFORE UPDATE OF value ON books_custom_column_1_link
                         BEGIN
                             SELECT CASE
                                 WHEN (SELECT id from custom_column_1 WHERE id=NEW.value) IS NULL
@@ -743,7 +743,7 @@ CREATE TRIGGER fkc_update_books_custom_column_2_link_a
                             END;
                         END;
 CREATE TRIGGER fkc_update_books_custom_column_2_link_b
-                        BEFORE UPDATE OF author ON books_custom_column_2_link
+                        BEFORE UPDATE OF value ON books_custom_column_2_link
                         BEGIN
                             SELECT CASE
                                 WHEN (SELECT id from custom_column_2 WHERE id=NEW.value) IS NULL


### PR DESCRIPTION
## Summary
- match custom column metadata insertion to Calibre's format
- create `custom_columns_idx` if missing
- correct trigger column names
- update example scripts

## Testing
- `php -l db.php`
- `php -l custom_column.php`
- `bash -n add_col.sh`


------
https://chatgpt.com/codex/tasks/task_e_68876190f9988329b26f85bb59857aa1