### PR TITLE
Refactor single-value custom columns

### DIFF
--- a/add_book.php
+++ b/add_book.php
@@ -40,9 +40,12 @@ try {
 
     // Assign default shelf
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $shelfTable = "custom_column_{$shelfId}";
-    $stmt = $pdo->prepare("INSERT OR IGNORE INTO $shelfTable (book, value) VALUES (:book, :val)");
-    $stmt->execute([':book' => $bookId, ':val' => 'Ebook Calibre']);
+    $shelfValTable = "custom_column_{$shelfId}";
+    $shelfLinkTable = "books_custom_column_{$shelfId}_link";
+    $pdo->prepare("INSERT OR IGNORE INTO $shelfValTable (value) VALUES ('Ebook Calibre')")->execute();
+    $shelfValId = $pdo->query("SELECT id FROM $shelfValTable WHERE value = 'Ebook Calibre'")->fetchColumn();
+    $pdo->prepare("INSERT INTO $shelfLinkTable (book, value) VALUES (:book, :val)")
+        ->execute([':book' => $bookId, ':val' => $shelfValId]);
 
     // Assign default status
     $statusId = ensureMultiValueColumn($pdo, '#status', 'Status');

--- a/book.php
+++ b/book.php
@@ -98,8 +98,9 @@ $tags = $tagsStmt->fetchColumn();
 // Fetch saved recommendations if present
 try {
     $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-    $table = "custom_column_{$recId}";
-    $recStmt = $pdo->prepare("SELECT value FROM $table WHERE book = ?");
+    $valueTable = "custom_column_{$recId}";
+    $linkTable  = "books_custom_column_{$recId}_link";
+    $recStmt = $pdo->prepare("SELECT v.value FROM $linkTable l JOIN $valueTable v ON l.value = v.id WHERE l.book = ?");
     $recStmt->execute([$id]);
     $savedRecommendations = $recStmt->fetchColumn();
 } catch (PDOException $e) {

--- a/delete_shelf.php
+++ b/delete_shelf.php
@@ -15,10 +15,20 @@ try {
     $stmt = $pdo->prepare('DELETE FROM shelves WHERE name = :name');
     $stmt->execute([':name' => $shelf]);
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $table = "custom_column_{$shelfId}";
+    $valueTable = "custom_column_{$shelfId}";
+    $linkTable  = "books_custom_column_{$shelfId}_link";
 
-    $stmt = $pdo->prepare("UPDATE $table SET value = 'Ebook Calibre' WHERE value = :old");
-    $stmt->execute([':old' => $shelf]);
+    $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES ('Ebook Calibre')")->execute();
+    $defaultId = $pdo->query("SELECT id FROM $valueTable WHERE value = 'Ebook Calibre'")->fetchColumn();
+    $oldStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :old");
+    $oldStmt->execute([':old' => $shelf]);
+    $oldId = $oldStmt->fetchColumn();
+    if ($oldId !== false) {
+        $pdo->prepare("UPDATE $linkTable SET value = :def WHERE value = :oldId")
+            ->execute([':def' => $defaultId, ':oldId' => $oldId]);
+        $pdo->prepare("DELETE FROM $valueTable WHERE id = :oldId")
+            ->execute([':oldId' => $oldId]);
+    }
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/list_books.php
+++ b/list_books.php
@@ -14,10 +14,13 @@ try {
     }
 
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $shelfTable = "custom_column_{$shelfId}";
-    $pdo->exec("INSERT OR IGNORE INTO $shelfTable (book, value)
-            SELECT id, 'Ebook Calibre' FROM books
-            WHERE id NOT IN (SELECT book FROM $shelfTable)");
+    $shelfValTable = "custom_column_{$shelfId}";
+    $shelfLinkTable = "books_custom_column_{$shelfId}_link";
+    $pdo->prepare("INSERT OR IGNORE INTO $shelfValTable (value) VALUES ('Ebook Calibre')")->execute();
+    $defaultId = $pdo->query("SELECT id FROM $shelfValTable WHERE value = 'Ebook Calibre'")->fetchColumn();
+    $pdo->exec("INSERT INTO $shelfLinkTable (book, value)
+            SELECT id, $defaultId FROM books
+            WHERE id NOT IN (SELECT book FROM $shelfLinkTable)");
 } catch (PDOException $e) {
     // Ignore errors if the table cannot be created
 }
@@ -58,14 +61,18 @@ try {
 // Ensure shelf column exists for recommendations block
 try {
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-    $shelfTable = "custom_column_{$shelfId}";
-    $pdo->exec("INSERT OR IGNORE INTO $shelfTable (book, value)\n            SELECT id, 'Ebook Calibre' FROM books\n            WHERE id NOT IN (SELECT book FROM $shelfTable)");
+    $shelfValTable = "custom_column_{$shelfId}";
+    $shelfLinkTable = "books_custom_column_{$shelfId}_link";
+    $pdo->prepare("INSERT OR IGNORE INTO $shelfValTable (value) VALUES ('Ebook Calibre')")->execute();
+    $defaultId = $pdo->query("SELECT id FROM $shelfValTable WHERE value = 'Ebook Calibre'")->fetchColumn();
+    $pdo->exec("INSERT INTO $shelfLinkTable (book, value)\n            SELECT id, $defaultId FROM books\n            WHERE id NOT IN (SELECT book FROM $shelfLinkTable)");
 } catch (PDOException $e) {
     // Ignore errors if the table cannot be created
 }
 
 $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-$recTable = "custom_column_{$recId}";
+$recValTable = "custom_column_{$recId}";
+$recLinkTable = "books_custom_column_{$recId}_link";
 $recColumnExists = true;
 
 $perPage = 20;
@@ -123,7 +130,7 @@ if ($genreName !== '') {
     $params[':genre_val'] = $genreName;
 }
 if ($shelfName !== '') {
-    $whereClauses[] = 'b.id IN (SELECT book FROM ' . $shelfTable . ' WHERE value = :shelf_name)';
+    $whereClauses[] = 'EXISTS (SELECT 1 FROM ' . $shelfLinkTable . ' sl JOIN ' . $shelfValTable . ' sv ON sl.value = sv.id WHERE sl.book = b.id AND sv.value = :shelf_name)';
     $params[':shelf_name'] = $shelfName;
 }
 if ($statusName !== '' && $statusTable) {
@@ -143,7 +150,7 @@ if ($statusName !== '' && $statusTable) {
     }
 }
 if ($recommendedOnly) {
-    $whereClauses[] = "EXISTS (SELECT 1 FROM $recTable WHERE book = b.id AND TRIM(COALESCE(value, '')) <> '')";
+    $whereClauses[] = "EXISTS (SELECT 1 FROM $recLinkTable rl JOIN $recValTable rv ON rl.value = rv.id WHERE rl.book = b.id AND TRIM(COALESCE(rv.value, '')) <> '')";
 }
 if ($search !== '') {
     $whereClauses[] = '(b.title LIKE :search OR EXISTS (
@@ -222,14 +229,15 @@ $books = [];
             }
         }
         if ($recColumnExists) {
-            $selectFields .= ", EXISTS(SELECT 1 FROM $recTable WHERE book = b.id AND TRIM(COALESCE(value, '')) <> '') AS has_recs";
+            $selectFields .= ", EXISTS(SELECT 1 FROM $recLinkTable rl JOIN $recValTable rv ON rl.value = rv.id WHERE rl.book = b.id AND TRIM(COALESCE(rv.value, '')) <> '') AS has_recs";
         }
 
         $sql = "SELECT $selectFields
                 FROM books b
                 LEFT JOIN books_series_link bsl ON bsl.book = b.id
                 LEFT JOIN series s ON bsl.series = s.id
-                LEFT JOIN $shelfTable bc11 ON bc11.book = b.id
+                LEFT JOIN $shelfLinkTable sl1 ON sl1.book = b.id
+                LEFT JOIN $shelfValTable bc11 ON bc11.id = sl1.value
                 LEFT JOIN comments com ON com.book = b.id";
         if ($statusTable) {
             if ($statusIsLink) {

--- a/recommend.php
+++ b/recommend.php
@@ -24,9 +24,16 @@ try {
         $pdo = getDatabaseConnection();
 
         $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-        $table = "custom_column_{$recId}";
-        $stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
-        $stmt->execute([':book' => $bookId, ':val' => $output]);
+        $valueTable = "custom_column_{$recId}";
+        $linkTable  = "books_custom_column_{$recId}_link";
+        $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+            ->execute([':val' => $output]);
+        $stmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+        $stmt->execute([':val' => $output]);
+        $valId = $stmt->fetchColumn();
+        $pdo->prepare("DELETE FROM $linkTable WHERE book = :book")->execute([':book' => $bookId]);
+        $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :val)")
+            ->execute([':book' => $bookId, ':val' => $valId]);
     }
 
     echo json_encode(['output' => $output]);

--- a/update_shelf.php
+++ b/update_shelf.php
@@ -21,10 +21,17 @@ if ($bookId <= 0 || !in_array($value, $allowed, true)) {
 }
 
 $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
-$table = "custom_column_{$shelfId}";
+$valueTable = "custom_column_{$shelfId}";
+$linkTable  = "books_custom_column_{$shelfId}_link";
 
-$stmt = $pdo->prepare("REPLACE INTO $table (book, value) VALUES (:book, :val)");
-$stmt->execute([':book' => $bookId, ':val' => $value]);
+$pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+    ->execute([':val' => $value]);
+$valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+$valStmt->execute([':val' => $value]);
+$valId = $valStmt->fetchColumn();
+$pdo->prepare("DELETE FROM $linkTable WHERE book = :book")->execute([':book' => $bookId]);
+$stmt = $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :val)");
+$stmt->execute([':book' => $bookId, ':val' => $valId]);
 
 echo json_encode(['status' => 'ok']);
 ?>

--- a/view_book.php
+++ b/view_book.php
@@ -47,8 +47,9 @@ $tags = $tagsStmt->fetchColumn();
 // Fetch saved recommendations from custom column, if present
 try {
     $recId = ensureSingleValueColumn($pdo, '#recommendation', 'Recommendation');
-    $table = "custom_column_{$recId}";
-    $recStmt = $pdo->prepare("SELECT value FROM $table WHERE book = ?");
+    $valueTable = "custom_column_{$recId}";
+    $linkTable  = "books_custom_column_{$recId}_link";
+    $recStmt = $pdo->prepare("SELECT v.value FROM $linkTable l JOIN $valueTable v ON l.value = v.id WHERE l.book = ?");
     $recStmt->execute([$id]);
     $savedRecommendations = $recStmt->fetchColumn();
 } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- migrate single-value columns to use calibre-style value and link tables
- convert existing data on first use of a legacy table
- add helpers for creating the new table structure
- adjust shelf and recommendation logic to work with link tables

## Testing
- `php -l db.php`
- `php -l add_book.php`
- `php -l update_shelf.php`
- `php -l rename_shelf.php`
- `php -l delete_shelf.php`
- `php -l book.php`
- `php -l view_book.php`
- `php -l recommend.php`
- `php -l list_books.php`

------
https://chatgpt.com/codex/tasks/task_e_6887824e959c8329a43b520219de6113