### PR TITLE
Fix author duplicates in add scripts

### DIFF
--- a/add_book_physical.php
+++ b/add_book_physical.php
@@ -34,7 +34,10 @@ function safe_filename($name, $max_length = 150) {
 }
 
 // --- Author Handling ---
-$authors = array_map('trim', preg_split('/,|;/', $authors_str));
+$authors = array_unique(array_filter(
+    array_map('trim', preg_split('/,|;/', $authors_str)),
+    'strlen'
+));
 $first_author = $authors[0];
 $author_folder_name = safe_filename($first_author . (count($authors) > 1 ? " et al." : ""));
 
@@ -57,7 +60,7 @@ $bookId = $pdo->lastInsertId();
 
 // Link book to authors
 foreach ($authors as $author) {
-    $pdo->exec("INSERT INTO books_authors_link (book, author)
+    $pdo->exec("INSERT OR IGNORE INTO books_authors_link (book, author)
                 SELECT $bookId, id FROM authors WHERE name=" . $pdo->quote($author));
 }
 

--- a/add_metadata_book.php
+++ b/add_metadata_book.php
@@ -26,7 +26,10 @@ if ($title === '' || $authors_str === '') {
 try {
     $pdo->beginTransaction();
 
-    $authors = array_map('trim', preg_split('/,|;/', $authors_str));
+    $authors = array_unique(array_filter(
+        array_map('trim', preg_split('/,|;/', $authors_str)),
+        'strlen'
+    ));
     $firstAuthor = $authors[0];
 
     foreach ($authors as $author) {
@@ -43,7 +46,7 @@ try {
     $bookId = (int)$pdo->lastInsertId();
 
     foreach ($authors as $author) {
-        $pdo->exec("INSERT INTO books_authors_link (book, author) SELECT $bookId, id FROM authors WHERE name=" . $pdo->quote($author));
+        $pdo->exec("INSERT OR IGNORE INTO books_authors_link (book, author) SELECT $bookId, id FROM authors WHERE name=" . $pdo->quote($author));
     }
 
     $tags = [];

--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -30,7 +30,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             $pdo->beginTransaction();
 
-            $authors = array_map('trim', preg_split('/,|;/', $authors_str));
+            $authors = array_unique(array_filter(
+                array_map('trim', preg_split('/,|;/', $authors_str)),
+                'strlen'
+            ));
             $firstAuthor = $authors[0];
 
             // Add authors
@@ -52,7 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             // Link authors
             foreach ($authors as $author) {
-                $pdo->exec("INSERT INTO books_authors_link (book, author) 
+                $pdo->exec("INSERT OR IGNORE INTO books_authors_link (book, author)
                             SELECT $bookId, id FROM authors WHERE name=" . $pdo->quote($author));
             }
 


### PR DESCRIPTION
## Summary
- deduplicate author list when adding metadata book
- ignore duplicate entries in books_authors_link
- apply same handling for physical book scripts

## Testing
- `php -l add_metadata_book.php`
- `php -l add_physical_book.php`
- `php -l add_book_physical.php`
- `php test_dup.php` (links:1)

------
https://chatgpt.com/codex/tasks/task_e_6887b1f5634c83298b47ba7640ebae0c