### PR TITLE
Add author-series sort by surname

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -94,7 +94,7 @@ if ($source === 'openlibrary') {
     header('Location: annas_results.php?' . http_build_query($redirectParams));
     exit;
 }
-$allowedSorts = ['title', 'author', 'series', 'author_series', 'recommended'];
+$allowedSorts = ['title', 'author', 'series', 'author_series', 'author_series_surname', 'recommended'];
 if (!in_array($sort, $allowedSorts, true)) {
     $sort = 'author_series';
 }
@@ -105,6 +105,7 @@ $orderByMap = [
     'author' => 'authors, b.title',
     'series' => 'series, b.series_index, b.title',
     'author_series' => 'authors, series, b.series_index, b.title',
+    'author_series_surname' => 'b.author_sort, series, b.series_index, b.title',
     'recommended' => 'authors, series, b.series_index, b.title'
 ];
 $orderBy = $orderByMap[$sort];

--- a/navbar.php
+++ b/navbar.php
@@ -80,6 +80,7 @@ $statusNameVal = isset($statusName) ? $statusName : '';
               <option value="author"<?= $sortVal === 'author' ? ' selected' : '' ?>>Author</option>
               <option value="series"<?= $sortVal === 'series' ? ' selected' : '' ?>>Series</option>
               <option value="author_series"<?= $sortVal === 'author_series' ? ' selected' : '' ?>>Author &amp; Series</option>
+              <option value="author_series_surname"<?= $sortVal === 'author_series_surname' ? ' selected' : '' ?>>Author &amp; Series Surname</option>
               <option value="recommended"<?= $sortVal === 'recommended' ? ' selected' : '' ?>>Recommended Only</option>
             </select>
           </div>


### PR DESCRIPTION
## Summary
- allow sorting by author surname with new `author_series_surname` option
- expose new sort option in the navigation bar

## Testing
- `php -l list_books.php`
- `php -l navbar.php`
- `php -l openlibrary_results.php`
- `php -l google_results.php`
- `php -l annas_results.php`


------
https://chatgpt.com/codex/tasks/task_e_6887ce3b873883298a0ff2cac467e3ed