### PR TITLE
Fix author_sort usage when updating metadata

### DIFF
--- a/book.php
+++ b/book.php
@@ -42,9 +42,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $authorsList = [$authorsInput];
         }
         $primaryAuthor = $authorsList[0];
-        $insertAuthor = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (:name, :sort)');
+        $insertAuthor = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (:name, author_sort(:name))');
         foreach ($authorsList as $a) {
-            $insertAuthor->execute([':name' => $a, ':sort' => $a]);
+            $insertAuthor->execute([':name' => $a]);
         }
         $pdo->prepare('DELETE FROM books_authors_link WHERE book = :book')->execute([':book' => $id]);
         foreach ($authorsList as $a) {
@@ -54,7 +54,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $linkStmt->execute([':book' => $id, ':author' => $aid]);
             }
         }
-        $pdo->prepare('UPDATE books SET author_sort = :sort WHERE id = :id')->execute([':sort' => $primaryAuthor, ':id' => $id]);
+        $pdo->prepare('UPDATE books SET author_sort = author_sort(:sort) WHERE id = :id')->execute([':sort' => $primaryAuthor, ':id' => $id]);
     }
 
     if ($descriptionInput !== '') {

--- a/update_metadata.php
+++ b/update_metadata.php
@@ -60,9 +60,9 @@ try {
             $authorsList = [$authors];
         }
         $primaryAuthor = $authorsList[0];
-        $insertAuthor = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (:name, :sort)');
+        $insertAuthor = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (:name, author_sort(:name))');
         foreach ($authorsList as $a) {
-            $insertAuthor->execute([':name' => $a, ':sort' => $a]);
+            $insertAuthor->execute([':name' => $a]);
         }
         $pdo->prepare('DELETE FROM books_authors_link WHERE book = :book')->execute([':book' => $bookId]);
         foreach ($authorsList as $a) {
@@ -72,7 +72,7 @@ try {
                 $linkStmt->execute([':book' => $bookId, ':author' => $aid]);
             }
         }
-        $pdo->prepare('UPDATE books SET author_sort = :sort WHERE id = :id')->execute([':sort' => $primaryAuthor, ':id' => $bookId]);
+        $pdo->prepare('UPDATE books SET author_sort = author_sort(:sort) WHERE id = :id')->execute([':sort' => $primaryAuthor, ':id' => $bookId]);
     }
 
     if ($descriptionPost !== '') {


### PR DESCRIPTION
## Summary
- ensure author metadata uses author_sort when editing a book
- update update_metadata.php to use author_sort

## Testing
- `php -l book.php`
- `php -l update_metadata.php`


------
https://chatgpt.com/codex/tasks/task_e_68880b6f729883299b6dcde3c98cc04b