### PR TITLE
Implement series editing features

### DIFF
--- a/rename_series.php
+++ b/rename_series.php
@@ -1,0 +1,24 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+requireLogin();
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$new = trim($_POST['new'] ?? '');
+if ($id <= 0 || $new === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid series']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare('UPDATE series SET name = :new, sort = :new WHERE id = :id');
+    $stmt->execute([':new' => $new, ':id' => $id]);
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>
+


### PR DESCRIPTION
## Summary
- allow renaming a series via new `rename_series.php` endpoint
- add Add Series and Edit Series buttons on book editing page
- update JS to handle adding and renaming series

## Testing
- `php -l rename_series.php`
- `php -l book.php`
- `php test_custom_columns.php` *(fails: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_688810fb03b88329867f6e7fb3c5d6bf