### PR TITLE
Enhance author sort workflow and cover display

### DIFF
--- a/book.php
+++ b/book.php
@@ -237,7 +237,10 @@ $missingFile = !bookHasFile($book['path']);
     <div class="row mb-4">
         <div class="col-md-3">
             <?php if (!empty($book['has_cover'])): ?>
-                <img src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>" alt="Cover" class="img-fluid">
+                <div class="position-relative d-inline-block">
+                    <img id="coverImagePreview" src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>" alt="Cover" class="img-thumbnail shadow-sm" style="max-width: 200px;">
+                    <div id="coverDimensions" class="position-absolute bottom-0 end-0 bg-dark text-white px-2 py-1 small rounded-top-start opacity-75" style="font-size: 1.2rem;">Loading...</div>
+                </div>
             <?php else: ?>
                 <div class="text-muted">No cover</div>
             <?php endif; ?>
@@ -299,7 +302,10 @@ $missingFile = !bookHasFile($book['path']);
                     <label for="authors" class="form-label">
                         <i class="fa-solid fa-user me-1 text-primary"></i> Author(s)
                     </label>
-                    <input type="text" id="authors" name="authors" value="<?= htmlspecialchars($book['authors']) ?>" class="form-control" placeholder="Separate multiple authors with commas" list="authorSuggestionsEdit">
+                    <div class="input-group">
+                        <input type="text" id="authors" name="authors" value="<?= htmlspecialchars($book['authors']) ?>" class="form-control" placeholder="Separate multiple authors with commas" list="authorSuggestionsEdit">
+                        <button type="button" id="applyAuthorSortBtn" class="btn btn-outline-secondary"><i class="fa-solid fa-arrow-right"></i></button>
+                    </div>
                     <datalist id="authorSuggestionsEdit"></datalist>
                 </div>
                 <div class="mb-3">
@@ -343,15 +349,6 @@ $missingFile = !bookHasFile($book['path']);
                     </label>
                     <input type="file" id="cover" name="cover" class="form-control">
                 </div>
-                <?php if (!empty($book['has_cover'])): ?>
-                    <div class="mb-3">
-                        <p class="mb-1"><i class="fa-solid fa-eye me-1 text-success"></i> Current Cover:</p>
-                        <div class="position-relative d-inline-block">
-                            <img id="coverImagePreview" src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>" alt="Cover" class="img-thumbnail shadow-sm" style="max-width: 200px;">
-                            <div id="coverDimensions" class="position-absolute bottom-0 end-0 bg-dark text-white px-2 py-1 small rounded-top-start opacity-75" style="font-size: 1.2rem;">Loading...</div>
-                        </div>
-                    </div>
-                <?php endif; ?>
                 <div class="d-flex justify-content-between">
                     <a href="list_books.php" class="btn btn-secondary">
                         <i class="fa-solid fa-arrow-left me-1"></i> Back to list

--- a/js/book.js
+++ b/js/book.js
@@ -269,6 +269,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const authorInput = document.getElementById('authors');
   const authorSortInput = document.getElementById('authorSort');
+  const applySortBtn = document.getElementById('applyAuthorSortBtn');
   const suggestionList = document.getElementById('authorSuggestionsEdit');
   function calcAuthorSort(str) {
     const first = str.split(/\s*(?:,|;| and )\s*/i)[0].trim();
@@ -305,6 +306,9 @@ document.addEventListener('DOMContentLoaded', () => {
       authorInput.addEventListener('input', updateAuthorSort);
       if (!authorSortInput.value) updateAuthorSort();
     }
+  }
+  if (applySortBtn) {
+    applySortBtn.addEventListener('click', updateAuthorSort);
   }
 
   const seriesSelect = document.getElementById('series');


### PR DESCRIPTION
## Summary
- add an apply button next to the **Author(s)** field to copy the generated author sort
- merge cover previews so only one image is used on `book.php`
- wire the new button into the existing JavaScript logic

## Testing
- `php -l book.php`
- `node -c js/book.js`

------
https://chatgpt.com/codex/tasks/task_e_688891da7d708329a3cbda3df78aad88