### PR TITLE
Show library base directory in book edit page

### DIFF
--- a/book.php
+++ b/book.php
@@ -353,6 +353,12 @@ $missingFile = !bookHasFile($book['path']);
                                     </label>
                                     <input type="text" id="authorSort" name="author_sort" value="<?= htmlspecialchars($book['author_sort']) ?>" class="form-control">
                                 </div>
+                                <div class="mb-3">
+                                    <label for="libraryBasePath" class="form-label">
+                                        <i class="fa-solid fa-folder-open me-1 text-primary"></i> Library Base Directory
+                                    </label>
+                                    <input type="text" id="libraryBasePath" class="form-control" value="<?= htmlspecialchars(getLibraryPath()) ?>" readonly>
+                                </div>
                             </div>
 
                             <!-- Series Info -->


### PR DESCRIPTION
## Summary
- display the Calibre library path on the Basic Info tab of `book.php`

## Testing
- `php -l book.php`
- `find . -name '*.php' -maxdepth 1 -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68889a4d36188329b88acb9b5ff38985