### PR TITLE
Align add-book endpoints with Calibre

### DIFF
--- a/add_metadata_book.php
+++ b/add_metadata_book.php
@@ -2,6 +2,63 @@
 require_once 'db.php';
 requireLogin();
 
+function touchLastModified(PDO $pdo, int $bookId): void {
+    $pdo->prepare('UPDATE books SET last_modified=CURRENT_TIMESTAMP WHERE id=?')->execute([$bookId]);
+}
+
+function fetchAdditionalMetadata(string $title, string $author): array {
+    $meta = [];
+    $url = 'https://openlibrary.org/search.json?title=' . urlencode($title) .
+           '&author=' . urlencode($author) .
+           '&limit=1&fields=edition_key,publisher,language,isbn';
+    $resp = @file_get_contents($url);
+    if ($resp !== false) {
+        $data = json_decode($resp, true);
+        if (isset($data['docs'][0])) {
+            $d = $data['docs'][0];
+            if (!empty($d['publisher'][0])) {
+                $meta['publisher'] = $d['publisher'][0];
+            }
+            if (!empty($d['language'][0])) {
+                $meta['languages'] = (array)$d['language'];
+            }
+            if (!empty($d['isbn'][0])) {
+                $meta['isbn'] = $d['isbn'][0];
+            }
+            if (!empty($d['edition_key'][0])) {
+                $edition = $d['edition_key'][0];
+                $eResp = @file_get_contents('https://openlibrary.org/books/' . $edition . '.json');
+                if ($eResp !== false) {
+                    $ed = json_decode($eResp, true);
+                    if (empty($meta['publisher']) && !empty($ed['publishers'][0])) {
+                        $meta['publisher'] = $ed['publishers'][0];
+                    }
+                    if (empty($meta['languages']) && !empty($ed['languages'])) {
+                        $meta['languages'] = [];
+                        foreach ($ed['languages'] as $l) {
+                            if (!empty($l['key'])) {
+                                $meta['languages'][] = basename($l['key']);
+                            }
+                        }
+                    }
+                    if (empty($meta['isbn'])) {
+                        $ids = $ed['identifiers'] ?? [];
+                        if (!empty($ids['isbn_13'][0])) {
+                            $meta['isbn'] = $ids['isbn_13'][0];
+                        } elseif (!empty($ids['isbn_10'][0])) {
+                            $meta['isbn'] = $ids['isbn_10'][0];
+                        }
+                    }
+                    if (!empty($ed['publish_date'])) {
+                        $meta['pubdate'] = $ed['publish_date'];
+                    }
+                }
+            }
+        }
+    }
+    return $meta;
+}
+
 function safe_filename(string $name, int $max_length = 150): string {
     $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
     return substr(trim($name), 0, $max_length);
@@ -32,6 +89,12 @@ try {
     ));
     $firstAuthor = $authors[0];
 
+    $extra = fetchAdditionalMetadata($title, $firstAuthor);
+    $publisher  = $extra['publisher'] ?? '';
+    $languages  = $extra['languages'] ?? ['eng'];
+    $identifier = $extra['isbn'] ?? '';
+    $pubdate    = $extra['pubdate'] ?? null;
+
     foreach ($authors as $author) {
         $stmt = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (?, author_sort(?))');
         $stmt->execute([$author, $author]);
@@ -45,9 +108,13 @@ try {
     $stmt->execute([$title, $title, $firstAuthor, $tmpPath]);
     $bookId = (int)$pdo->lastInsertId();
 
+    $pdo->prepare('INSERT OR IGNORE INTO metadata_dirtied (book) VALUES (?)')->execute([$bookId]);
+    touchLastModified($pdo, $bookId);
+
     foreach ($authors as $author) {
         $pdo->exec("INSERT OR IGNORE INTO books_authors_link (book, author) SELECT $bookId, id FROM authors WHERE name=" . $pdo->quote($author));
     }
+    touchLastModified($pdo, $bookId);
 
     $tags = [];
     if ($tags_str !== '') {
@@ -57,6 +124,7 @@ try {
             $pdo->exec("INSERT INTO books_tags_link (book, tag) SELECT $bookId, id FROM tags WHERE name=" . $pdo->quote($tag));
         }
     }
+    touchLastModified($pdo, $bookId);
 
     $authorFolderName = safe_filename($firstAuthor . (count($authors) > 1 ? ' et al.' : ''));
     $bookFolderName = safe_filename($title) . " ($bookId)";
@@ -71,10 +139,13 @@ try {
     }
 
     $pdo->prepare('UPDATE books SET path = ? WHERE id = ?')->execute([$bookPath, $bookId]);
+    $pdo->prepare('UPDATE books SET timestamp=CURRENT_TIMESTAMP WHERE id=?')->execute([$bookId]);
+    touchLastModified($pdo, $bookId);
 
     if ($description !== '') {
         $stmt = $pdo->prepare('INSERT INTO comments (book, text) VALUES (:book, :text)');
         $stmt->execute([':book' => $bookId, ':text' => $description]);
+        touchLastModified($pdo, $bookId);
     }
 
     if ($thumbnail !== '') {
@@ -82,7 +153,32 @@ try {
         if ($data !== false) {
             file_put_contents($fullBookFolder . '/cover.jpg', $data);
             $pdo->prepare('UPDATE books SET has_cover = 1 WHERE id = ?')->execute([$bookId]);
+            touchLastModified($pdo, $bookId);
         }
+    }
+
+    if ($publisher !== '') {
+        $pdo->prepare('INSERT OR IGNORE INTO publishers(name) VALUES (?)')->execute([$publisher]);
+        $pdo->prepare('DELETE FROM books_publishers_link WHERE book=?')->execute([$bookId]);
+        $pdo->prepare('INSERT INTO books_publishers_link(book,publisher) SELECT ?, id FROM publishers WHERE name=?')->execute([$bookId, $publisher]);
+        touchLastModified($pdo, $bookId);
+    }
+
+    $pdo->prepare('DELETE FROM books_languages_link WHERE book=?')->execute([$bookId]);
+    foreach ($languages as $lang) {
+        $pdo->prepare('INSERT INTO books_languages_link(book,lang_code) VALUES(?, ?)')->execute([$bookId, $lang]);
+    }
+    touchLastModified($pdo, $bookId);
+
+    if ($pubdate !== null) {
+        $pdo->prepare('UPDATE books SET pubdate=? WHERE id=?')->execute([$pubdate, $bookId]);
+        touchLastModified($pdo, $bookId);
+    }
+
+    if ($identifier !== '') {
+        $pdo->prepare('DELETE FROM identifiers WHERE book=?')->execute([$bookId]);
+        $pdo->prepare('INSERT OR REPLACE INTO identifiers (book, type, val) VALUES (?, ?, ?)')->execute([$bookId, 'isbn', $identifier]);
+        touchLastModified($pdo, $bookId);
     }
 
     $uuid = $pdo->query("SELECT uuid FROM books WHERE id = $bookId")->fetchColumn();
@@ -96,13 +192,18 @@ try {
     $descriptionXml = $description !== ''
         ? "    <dc:description>" . htmlspecialchars($description) . "</dc:description>\n"
         : '';
+    $languageCode = $languages[0] ?? 'eng';
+    $publisherXml = $publisher !== '' ? "    <dc:publisher>" . htmlspecialchars($publisher) . "</dc:publisher>\n" : '';
+    $isbnXml = $identifier !== '' ? "    <dc:identifier opf:scheme=\"ISBN\">$identifier</dc:identifier>\n" : '';
     $opf = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<package version=\"2.0\" xmlns=\"http://www.idpf.org/2007/opf\">\n  <metadata>\n" .
            "    <dc:title>" . htmlspecialchars($title) . "</dc:title>\n" .
            "    <dc:creator opf:role=\"aut\">" . htmlspecialchars($firstAuthor) . "</dc:creator>\n" .
+           $publisherXml .
            $tagsXml .
            $descriptionXml .
-           "    <dc:language>eng</dc:language>\n" .
+           "    <dc:language>" . htmlspecialchars($languageCode) . "</dc:language>\n" .
            "    <dc:identifier opf:scheme=\"uuid\">$uuid</dc:identifier>\n" .
+           $isbnXml .
            "    <meta name=\"calibre:timestamp\" content=\"$timestamp+00:00\"/>\n" .
            "  </metadata>\n</package>";
     file_put_contents($fullBookFolder . '/metadata.opf', $opf);

--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -2,6 +2,63 @@
 require_once 'db.php';
 requireLogin();
 
+function touchLastModified(PDO $pdo, int $bookId): void {
+    $pdo->prepare('UPDATE books SET last_modified=CURRENT_TIMESTAMP WHERE id=?')->execute([$bookId]);
+}
+
+function fetchAdditionalMetadata(string $title, string $author): array {
+    $meta = [];
+    $url = 'https://openlibrary.org/search.json?title=' . urlencode($title) .
+           '&author=' . urlencode($author) .
+           '&limit=1&fields=edition_key,publisher,language,isbn';
+    $resp = @file_get_contents($url);
+    if ($resp !== false) {
+        $data = json_decode($resp, true);
+        if (isset($data['docs'][0])) {
+            $d = $data['docs'][0];
+            if (!empty($d['publisher'][0])) {
+                $meta['publisher'] = $d['publisher'][0];
+            }
+            if (!empty($d['language'][0])) {
+                $meta['languages'] = (array)$d['language'];
+            }
+            if (!empty($d['isbn'][0])) {
+                $meta['isbn'] = $d['isbn'][0];
+            }
+            if (!empty($d['edition_key'][0])) {
+                $edition = $d['edition_key'][0];
+                $eResp = @file_get_contents('https://openlibrary.org/books/' . $edition . '.json');
+                if ($eResp !== false) {
+                    $ed = json_decode($eResp, true);
+                    if (empty($meta['publisher']) && !empty($ed['publishers'][0])) {
+                        $meta['publisher'] = $ed['publishers'][0];
+                    }
+                    if (empty($meta['languages']) && !empty($ed['languages'])) {
+                        $meta['languages'] = [];
+                        foreach ($ed['languages'] as $l) {
+                            if (!empty($l['key'])) {
+                                $meta['languages'][] = basename($l['key']);
+                            }
+                        }
+                    }
+                    if (empty($meta['isbn'])) {
+                        $ids = $ed['identifiers'] ?? [];
+                        if (!empty($ids['isbn_13'][0])) {
+                            $meta['isbn'] = $ids['isbn_13'][0];
+                        } elseif (!empty($ids['isbn_10'][0])) {
+                            $meta['isbn'] = $ids['isbn_10'][0];
+                        }
+                    }
+                    if (!empty($ed['publish_date'])) {
+                        $meta['pubdate'] = $ed['publish_date'];
+                    }
+                }
+            }
+        }
+    }
+    return $meta;
+}
+
 function safe_filename(string $name, int $max_length = 150): string {
     $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
     return substr(trim($name), 0, $max_length);
@@ -36,6 +93,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ));
             $firstAuthor = $authors[0];
 
+            $extra = fetchAdditionalMetadata($title, $firstAuthor);
+            $publisher  = $extra['publisher'] ?? '';
+            $languages  = $extra['languages'] ?? ['eng'];
+            $identifier = $extra['isbn'] ?? '';
+            $pubdate    = $extra['pubdate'] ?? null;
+
             // Add authors
             foreach ($authors as $author) {
                 $stmt = $pdo->prepare('INSERT OR IGNORE INTO authors (name, sort) VALUES (?, author_sort(?))');
@@ -52,12 +115,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             );
             $stmt->execute([$title, $title, $firstAuthor, $tmpPath]);
             $bookId = (int)$pdo->lastInsertId();
+            $pdo->prepare('INSERT OR IGNORE INTO metadata_dirtied (book) VALUES (?)')->execute([$bookId]);
+            touchLastModified($pdo, $bookId);
 
             // Link authors
             foreach ($authors as $author) {
                 $pdo->exec("INSERT OR IGNORE INTO books_authors_link (book, author)
                             SELECT $bookId, id FROM authors WHERE name=" . $pdo->quote($author));
             }
+            touchLastModified($pdo, $bookId);
 
             // Add tags
             $tags = [];
@@ -65,10 +131,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $tags = array_map('trim', preg_split('/,|;/', $tags_str));
                 foreach ($tags as $tag) {
                     $pdo->exec("INSERT OR IGNORE INTO tags (name) VALUES (" . $pdo->quote($tag) . ")");
-                    $pdo->exec("INSERT INTO books_tags_link (book, tag) 
+                    $pdo->exec("INSERT INTO books_tags_link (book, tag)
                                 SELECT $bookId, id FROM tags WHERE name=" . $pdo->quote($tag));
                 }
             }
+            touchLastModified($pdo, $bookId);
 
             // Build proper folder structure
             $authorFolderName = safe_filename($firstAuthor . (count($authors) > 1 ? ' et al.' : ''));
@@ -85,6 +152,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             // Update book path in database
             $pdo->prepare('UPDATE books SET path = ? WHERE id = ?')->execute([$bookPath, $bookId]);
+            $pdo->prepare('UPDATE books SET timestamp=CURRENT_TIMESTAMP WHERE id=?')->execute([$bookId]);
+            touchLastModified($pdo, $bookId);
 
             // Move uploaded file
             $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
@@ -95,6 +164,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             // Add entry to 'data' table (linking the book to its file format)
             $stmt = $pdo->prepare('INSERT INTO data (book, format, uncompressed_size, name) VALUES (?, ?, ?, ?)');
             $stmt->execute([$bookId, strtoupper($ext), filesize($destFile), $baseFileName]);
+            touchLastModified($pdo, $bookId);
+
+            if ($publisher !== '') {
+                $pdo->prepare('INSERT OR IGNORE INTO publishers(name) VALUES (?)')->execute([$publisher]);
+                $pdo->prepare('DELETE FROM books_publishers_link WHERE book=?')->execute([$bookId]);
+                $pdo->prepare('INSERT INTO books_publishers_link(book,publisher) SELECT ?, id FROM publishers WHERE name=?')->execute([$bookId, $publisher]);
+                touchLastModified($pdo, $bookId);
+            }
+
+            $pdo->prepare('DELETE FROM books_languages_link WHERE book=?')->execute([$bookId]);
+            foreach ($languages as $lang) {
+                $pdo->prepare('INSERT INTO books_languages_link(book,lang_code) VALUES(?, ?)')->execute([$bookId, $lang]);
+            }
+            touchLastModified($pdo, $bookId);
+
+            if ($pubdate !== null) {
+                $pdo->prepare('UPDATE books SET pubdate=? WHERE id=?')->execute([$pubdate, $bookId]);
+                touchLastModified($pdo, $bookId);
+            }
+
+            if ($identifier !== '') {
+                $pdo->prepare('DELETE FROM identifiers WHERE book=?')->execute([$bookId]);
+                $pdo->prepare('INSERT OR REPLACE INTO identifiers (book, type, val) VALUES (?, ?, ?)')->execute([$bookId, 'isbn', $identifier]);
+                touchLastModified($pdo, $bookId);
+            }
 
             // Fetch the UUID from the database
             $uuid = $pdo->query("SELECT uuid FROM books WHERE id = $bookId")->fetchColumn();
@@ -106,12 +200,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
 
             $timestamp = date('Y-m-d\TH:i:s');
+            $languageCode = $languages[0] ?? 'eng';
+            $publisherXml = $publisher !== '' ? "    <dc:publisher>" . htmlspecialchars($publisher) . "</dc:publisher>\n" : '';
+            $isbnXml = $identifier !== '' ? "    <dc:identifier opf:scheme=\"ISBN\">$identifier</dc:identifier>\n" : '';
             $opf = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<package version=\"2.0\" xmlns=\"http://www.idpf.org/2007/opf\">\n  <metadata>\n" .
                    "    <dc:title>" . htmlspecialchars($title) . "</dc:title>\n" .
                    "    <dc:creator opf:role=\"aut\">" . htmlspecialchars($firstAuthor) . "</dc:creator>\n" .
+                   $publisherXml .
                    $tagsXml .
-                   "    <dc:language>eng</dc:language>\n" .
+                   "    <dc:language>" . htmlspecialchars($languageCode) . "</dc:language>\n" .
                    "    <dc:identifier opf:scheme=\"uuid\">$uuid</dc:identifier>\n" .
+                   $isbnXml .
                    "    <meta name=\"calibre:timestamp\" content=\"$timestamp+00:00\"/>\n" .
                    "  </metadata>\n</package>";
             file_put_contents($fullBookFolder . '/metadata.opf', $opf);


### PR DESCRIPTION
## Summary
- fetch extra metadata (publisher, language, isbn) from Open Library when adding a book
- mark books as dirtied and update timestamps
- record publishers, languages, identifiers and pubdate like Calibre
- include metadata in generated `metadata.opf`

## Testing
- `php -l add_metadata_book.php`
- `php -l add_physical_book.php`

------
https://chatgpt.com/codex/tasks/task_e_6888a15764c883299f9efe6c46d47622