### PR TITLE
Use ebook-meta to fill metadata

### DIFF
--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -282,5 +282,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </form>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+const fileInput = document.getElementById('file');
+const titleInput = document.getElementById('title');
+const authorsInput = document.getElementById('authors');
+if (fileInput) {
+  fileInput.addEventListener('change', () => {
+    if (!fileInput.files.length) return;
+    const fd = new FormData();
+    fd.append('file', fileInput.files[0]);
+    fetch('ebook_meta.php', { method: 'POST', body: fd })
+      .then(r => r.json())
+      .then(data => {
+        if (data.title && !titleInput.value) titleInput.value = data.title;
+        if (data.authors && !authorsInput.value) {
+          authorsInput.value = data.authors.replace(/ and /g, ', ');
+        }
+      })
+      .catch(() => {});
+  });
+}
+</script>
 </body>
 </html>

--- a/book.php
+++ b/book.php
@@ -193,6 +193,7 @@ if (!empty($book['path'])) {
     $bookFolderName = safe_filename($book['title']) . ' (' . $book['id'] . ')';
     $libraryDirPath .= '/' . $authorFolderName . '/' . $bookFolderName;
 }
+$ebookFileRel = $missingFile ? '' : firstBookFile($book['path']);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -207,7 +208,7 @@ if (!empty($book['path'])) {
         #description { min-height: 200px; resize: vertical; }
     </style>
 </head>
-<body class="pt-5" data-book-id="<?= (int)$book['id'] ?>" data-search-query="<?= htmlspecialchars($book['title'] . ' ' . $book['authors'], ENT_QUOTES) ?>">
+<body class="pt-5" data-book-id="<?= (int)$book['id'] ?>" data-search-query="<?= htmlspecialchars($book['title'] . ' ' . $book['authors'], ENT_QUOTES) ?>"<?php if($ebookFileRel): ?> data-ebook-file="<?= htmlspecialchars($ebookFileRel) ?>"<?php endif; ?>>
 <?php include "navbar.php"; ?>
 <div class="container my-4">
     <a href="list_books.php" class="btn btn-secondary mb-3">
@@ -256,6 +257,9 @@ if (!empty($book['path'])) {
             <a href="<?= htmlspecialchars($annasUrl) ?>" class="btn btn-secondary">Anna's Archive</a>
             <button type="button" id="annasMetaBtn" class="btn btn-secondary">Get Metadata</button>
             <button type="button" id="googleMetaBtn" class="btn btn-secondary">Google Metadata</button>
+            <?php if (!$missingFile && $ebookFileRel): ?>
+            <button type="button" id="ebookMetaBtn" class="btn btn-secondary">File Metadata</button>
+            <?php endif; ?>
         </div>
         <?php if ($missingFile): ?>
             <div class="btn-group mb-2">

--- a/db.php
+++ b/db.php
@@ -125,6 +125,19 @@ function bookHasFile(string $relativePath): bool {
     return false;
 }
 
+function firstBookFile(string $relativePath): ?string {
+    $library = getLibraryPath();
+    $dir = $library . '/' . $relativePath;
+    if (!is_dir($dir)) {
+        return null;
+    }
+    $files = glob($dir . '/*.{epub,mobi,azw3,pdf,txt}', GLOB_BRACE);
+    if ($files) {
+        return substr($files[0], strlen($library) + 1);
+    }
+    return null;
+}
+
 function getDatabaseConnection(?string $path = null) {
     $path = $path ?? currentDatabasePath();
     try {

--- a/ebook_meta.php
+++ b/ebook_meta.php
@@ -1,0 +1,54 @@
+<?php
+require_once 'db.php';
+requireLogin();
+
+header('Content-Type: application/json');
+
+function parse_ebook_meta(string $text): array {
+    $result = [];
+    foreach (preg_split("/[\r\n]+/", $text) as $line) {
+        if (strpos($line, ':') === false) continue;
+        list($k, $v) = array_map('trim', explode(':', $line, 2));
+        $k = strtolower($k);
+        if ($k === 'author(s)') $k = 'authors';
+        if ($k === 'identifiers') $k = 'identifier';
+        $result[$k] = $v;
+    }
+    return $result;
+}
+
+$path = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $file = $_FILES['file'] ?? null;
+    if (!$file || $file['error'] !== UPLOAD_ERR_OK) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid file']);
+        exit;
+    }
+    $path = $file['tmp_name'];
+} else {
+    $rel = ltrim($_GET['path'] ?? '', '/');
+    if ($rel === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing path']);
+        exit;
+    }
+    $abs = getLibraryPath() . '/' . $rel;
+    if (!file_exists($abs)) {
+        http_response_code(404);
+        echo json_encode(['error' => 'File not found']);
+        exit;
+    }
+    $path = $abs;
+}
+
+$out = shell_exec('ebook-meta ' . escapeshellarg($path) . ' 2>/dev/null');
+if ($out === null) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to run ebook-meta']);
+    exit;
+}
+$data = parse_ebook_meta($out);
+$data['status'] = 'ok';
+
+echo json_encode($data);

--- a/js/book.js
+++ b/js/book.js
@@ -54,6 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const recommendSection = document.getElementById('recommendSection');
   const synopsisBtn = document.getElementById('synopsisBtn');
   const descriptionInput = document.getElementById('description');
+  const titleInput = document.getElementById('title');
 
   if (recommendSection.dataset.saved) {
     recommendSection.innerHTML = renderRecommendations(recommendSection.dataset.saved);
@@ -73,6 +74,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const googleResults = document.getElementById('googleResults');
   const googleModalEl = document.getElementById('googleModal');
   const googleModal = new bootstrap.Modal(googleModalEl);
+
+  const ebookBtn = document.getElementById('ebookMetaBtn');
+  const ebookFile = bodyData.ebookFile;
 
   recommendBtn.addEventListener('click', () => {
     const bookId = recommendBtn.dataset.bookId;
@@ -180,6 +184,24 @@ document.addEventListener('DOMContentLoaded', () => {
       .catch(() => { googleResults.textContent = 'Error fetching results'; });
     googleModal.show();
   });
+
+  if (ebookBtn && ebookFile) {
+    ebookBtn.addEventListener('click', () => {
+      fetch('ebook_meta.php?path=' + encodeURIComponent(ebookFile))
+        .then(r => r.json())
+        .then(data => {
+          if (data.title && titleInput) titleInput.value = data.title;
+          if (data.authors && authorInput) {
+            authorInput.value = data.authors.replace(/ and /g, ', ');
+            updateAuthorSort();
+          }
+          if (data.comments && descriptionInput) {
+            descriptionInput.value = data.comments;
+          }
+        })
+        .catch(() => { alert('Error reading metadata'); });
+    });
+  }
 
   document.addEventListener('click', e => {
     if (e.target.classList.contains('annas-use')) {


### PR DESCRIPTION
## Summary
- create `ebook_meta.php` to invoke `ebook-meta` on a file or upload
- add `firstBookFile()` helper to find a book file
- expose file path to book.js and new "File Metadata" button
- auto-fill metadata from ebook files in `book.php`
- when uploading a book, parse metadata from the uploaded file

## Testing
- `php -l ebook_meta.php`
- `php -l book.php`
- `php -l add_physical_book.php`
- `node -c js/book.js`
- `php test_custom_columns.php` *(fails: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_6888b0931de8832989736d2529922fda