### PR TITLE
Improve author sorting

### DIFF
--- a/AuthorSortClass.php
+++ b/AuthorSortClass.php
@@ -101,7 +101,7 @@ class AuthorSort
 }
 
 // --- Example usage ---
-$sorter = new AuthorSort('invert');
-echo $sorter->sort("Vincent van Gogh & John Smith Jr.") . "\n";
+// $sorter = new AuthorSort('invert');
+// echo $sorter->sort("Vincent van Gogh & John Smith Jr.") . "\n";
 // Output: "van Gogh, Vincent & Smith Jr., John"
 

--- a/js/book.js
+++ b/js/book.js
@@ -311,29 +311,35 @@ document.addEventListener('DOMContentLoaded', () => {
   const applySortBtn = document.getElementById('applyAuthorSortBtn');
   const suggestionList = document.getElementById('authorSuggestionsEdit');
   function calcAuthorSort(str) {
-    const first = str.split(/\s*(?:,|;| and )\s*/i)[0].trim();
-    if (!first) return '';
-    if (first.includes(',')) return first;
-
     const particles = ['da','de','del','della','di','du','la','le','van','von','der','den','ter','ten','el'];
     const suffixes  = ['jr','jr.','sr','sr.','ii','iii','iv'];
 
-    const parts = first.split(/\s+/);
-    if (parts.length <= 1) return first;
+    function invert(name) {
+      name = name.trim();
+      if (!name) return '';
+      if (name.includes(',')) return name;
 
-    let suffix = '';
-    const last = parts[parts.length - 1].toLowerCase();
-    if (suffixes.includes(last)) {
-      suffix = ' ' + parts.pop();
+      const parts = name.split(/\s+/);
+      if (parts.length <= 1) return name;
+
+      let suffix = '';
+      const last = parts[parts.length - 1].toLowerCase();
+      if (suffixes.includes(last)) {
+        suffix = ' ' + parts.pop();
+      }
+
+      let lastName = parts.pop();
+      while (parts.length > 0 && particles.includes(parts[parts.length - 1].toLowerCase())) {
+        lastName = parts.pop() + ' ' + lastName;
+      }
+
+      const firstNames = parts.join(' ');
+      return `${lastName}${suffix}, ${firstNames}`.trim();
     }
 
-    let lastName = parts.pop();
-    while (parts.length > 0 && particles.includes(parts[parts.length - 1].toLowerCase())) {
-      lastName = parts.pop() + ' ' + lastName;
-    }
-
-    const firstNames = parts.join(' ');
-    return `${lastName}${suffix}, ${firstNames}`.trim();
+    const authors = str.split(/\s*(?:&| and )\s*/i).filter(a => a.trim());
+    const sorted = authors.map(a => invert(a));
+    return sorted.join(' & ');
   }
   function updateAuthorSort() {
     if (authorInput && authorSortInput) {


### PR DESCRIPTION
## Summary
- silence author sort example output
- register AuthorSort class with SQLite so it matches the class logic
- compute author sort for all authors on the client side

## Testing
- `php -l db.php`
- `php -l AuthorSortClass.php`
- `node --check js/book.js`


------
https://chatgpt.com/codex/tasks/task_e_6888bdd5b6188329916d51a210245b89