### PR TITLE
Add book rating functionality

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -131,6 +131,14 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({ book_id: bookId, value })
       });
+    } else if (e.target.classList.contains('rating-select')) {
+      const bookId = e.target.dataset.bookId;
+      const value = e.target.value;
+      await fetch('update_rating.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ book_id: bookId, value })
+      });
     }
   });
 

--- a/update_rating.php
+++ b/update_rating.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+requireLogin();
+
+$bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
+$value = isset($_POST['value']) ? (int)$_POST['value'] : 0;
+
+if ($bookId <= 0 || $value < 0 || $value > 5) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid input']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+
+try {
+    $pdo->prepare('DELETE FROM books_ratings_link WHERE book = ?')->execute([$bookId]);
+    if ($value > 0) {
+        $ratingVal = $value * 2;
+        $pdo->prepare('INSERT OR IGNORE INTO ratings (rating) VALUES (?)')->execute([$ratingVal]);
+        $stmt = $pdo->prepare('SELECT id FROM ratings WHERE rating = ?');
+        $stmt->execute([$ratingVal]);
+        $ratingId = $stmt->fetchColumn();
+        $pdo->prepare('INSERT INTO books_ratings_link (book, rating) VALUES (?, ?)')->execute([$bookId, $ratingId]);
+    }
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- allow setting per-book ratings
- fetch existing rating in book list
- display rating dropdown after status
- handle rating updates with new API endpoint

## Testing
- `php -l list_books.php`
- `php -l update_rating.php`
- `node -c js/list_books.js >/dev/null 2>&1 && echo 'syntax ok'`

------
https://chatgpt.com/codex/tasks/task_e_6888ee77cce0832995e54a1d6e191aea