### PR TITLE
Fix rating updates not persisting

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -137,6 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
       await fetch('update_rating.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        credentials: 'same-origin',
         body: new URLSearchParams({ book_id: bookId, value })
       });
     }


### PR DESCRIPTION
## Summary
- ensure cookies are sent when saving a rating so the server writes to the right database

## Testing
- `php -l js/list_books.js`
- `php -l update_rating.php`


------
https://chatgpt.com/codex/tasks/task_e_6888f38124ec8329a2447da07f447d30