### PR TITLE
Add reader link from list page

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -306,6 +306,7 @@ $baseUrl .= '&page=';
 function render_book_rows(array $books, array $shelfList, array $statusOptions, array $genreList, string $sort, ?int $authorId, ?int $seriesId): void {
     foreach ($books as $book) {
         $missing = !bookHasFile($book['path']);
+        $firstFile = $missing ? null : firstBookFile($book['path']);
         ?>
         <div class="row g-3 py-3 border-bottom" data-book-block-id="<?= htmlspecialchars($book['id']) ?>">
             <!-- Left: Thumbnail -->
@@ -434,6 +435,9 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                     <!-- Actions -->
                     <div class="ms-auto d-flex align-items-end">
                         <a class="btn btn-sm btn-primary me-1" href="book.php?id=<?= urlencode($book['id']) ?>">View / Edit</a>
+                        <?php if ($firstFile): ?>
+                            <a class="btn btn-sm btn-success me-1" href="reader.php?file=<?= urlencode($firstFile) ?>">Read</a>
+                        <?php endif; ?>
                         <button type="button" class="btn btn-sm btn-secondary google-meta me-1"
                                 data-book-id="<?= htmlspecialchars($book['id']) ?>"
                                 data-search="<?= htmlspecialchars($book['title'] . ' ' . $book['authors'], ENT_QUOTES) ?>">

--- a/reader.php
+++ b/reader.php
@@ -1,7 +1,19 @@
 <?php
-// Path to your EPUB file
-$bookFile = "/book.epub"; 
-$bookFileEncoded = dirname($bookFile) . '/' . rawurlencode(basename($bookFile));
+require_once 'db.php';
+requireLogin();
+
+$fileParam = $_GET['file'] ?? '';
+$bookFile = '';
+if ($fileParam !== '') {
+    $library = getLibraryPath();
+    $abs = realpath($library . '/' . $fileParam);
+    if ($abs !== false && strpos($abs, realpath($library)) === 0 && is_file($abs)) {
+        $bookFile = '/' . ltrim($fileParam, '/');
+    }
+}
+$bookFileEncoded = $bookFile !== ''
+    ? dirname($bookFile) . '/' . rawurlencode(basename($bookFile))
+    : '';
 ?>
 
 


### PR DESCRIPTION
## Summary
- enable `reader.php` to load a book via query parameter
- add `Read` button in `list_books.php` linking to reader page

## Testing
- `php -l reader.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_6889e5a62fb48329bb91db7d75f1ca12