### PR TITLE
Add automatic PDF conversion

### DIFF
--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -175,6 +175,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $destFile = $fullBookFolder . '/' . $baseFileName . '.' . $ext;
             move_uploaded_file($file['tmp_name'], $destFile);
 
+            // If the upload is a PDF, clean/convert and create an EPUB
+            if ($ext === 'pdf') {
+                $pdfFile = $destFile;
+                exec('ocrmypdf --find-text ' . escapeshellarg($pdfFile) . ' /dev/null 2>/dev/null', $out, $rv);
+                if ($rv !== 0) {
+                    $tmpPdf = $fullBookFolder . '/' . $baseFileName . '_tmp.pdf';
+                    shell_exec('ocrmypdf -l eng --skip-text --deskew --clean --optimize 3 '
+                        . escapeshellarg($pdfFile) . ' ' . escapeshellarg($tmpPdf));
+                    if (file_exists($tmpPdf)) {
+                        rename($tmpPdf, $pdfFile);
+                    }
+                }
+                $epubFile = $fullBookFolder . '/' . $baseFileName . '.epub';
+                shell_exec('ebook-convert ' . escapeshellarg($pdfFile) . ' ' . escapeshellarg($epubFile)
+                    . ' --enable-heuristics --base-font-size 12 --unwrap-factor 0.45'
+                    . ' --margin-left 10 --margin-right 10 --margin-top 10 --margin-bottom 10'
+                    . ' --remove-paragraph-spacing --remove-paragraph-spacing-indent-size 1.5');
+                $destFile = $epubFile;
+                $ext = 'epub';
+            }
+
             // Add entry to 'data' table (linking the book to its file format)
             $stmt = $pdo->prepare('INSERT INTO data (book, format, uncompressed_size, name) VALUES (?, ?, ?, ?)');
             $stmt->execute([$bookId, strtoupper($ext), filesize($destFile), $baseFileName]);


### PR DESCRIPTION
## Summary
- convert uploaded PDFs to text using `ocrmypdf` if necessary
- convert PDFs to EPUBs with `ebook-convert`
- store the EPUB in the database and keep the PDF as a backup

## Testing
- `php -l add_physical_book.php`
- `php -l upload_book_file.php`


------
https://chatgpt.com/codex/tasks/task_e_688a14cb36f48329a97785c8144abf07