### PR TITLE
Remove PDFs shelf and add notes column

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ When a different Calibre library is selected, the application ensures that all r
 
 Each book also has a "Shelf" value stored in the custom column labeled `#shelf`. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
+Books can now store freeform notes in the single-value custom column labeled `#notes`.
+
 Genres are stored in the custom column labeled `genre` and listed in the sidebar. You can add,
 rename or delete genres from that list just like shelves and status values.
 

--- a/add_shelf.php
+++ b/add_shelf.php
@@ -14,7 +14,7 @@ $pdo = getDatabaseConnection();
 try {
     $stmt = $pdo->prepare('CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)');
     $stmt->execute();
-    $defaults = ['Physical', 'Ebook Calibre', 'PDFs'];
+    $defaults = ['Physical', 'Ebook Calibre'];
     foreach ($defaults as $d) {
         $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$d]);
     }

--- a/db.php
+++ b/db.php
@@ -190,7 +190,7 @@ function initializeCustomColumns(PDO $pdo): void {
     try {
         // 1. Ensure the shelves table (custom app table, not part of Calibre itself)
         $pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
-        foreach (['Physical', 'Ebook Calibre', 'PDFs'] as $def) {
+        foreach (['Physical', 'Ebook Calibre'] as $def) {
             $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$def]);
         }
 
@@ -207,6 +207,9 @@ function initializeCustomColumns(PDO $pdo): void {
         // 5. Ensure Status column (multi-value)
         $statusId = ensureMultiValueColumn($pdo, 'status', 'Status');
         insertDefaultMultiValue($pdo, $statusId, 'Want to Read');
+
+        // 6. Ensure Notes column (single-value)
+        ensureSingleValueColumn($pdo, 'notes', 'Notes');
 
     } catch (PDOException $e) {
         error_log("initializeCustomColumns error: " . $e->getMessage());

--- a/list_books.php
+++ b/list_books.php
@@ -9,7 +9,7 @@ $genreLinkTable = "books_custom_column_{$genreColumnId}_link";
 // Ensure shelf table and custom column exist
 try {
     $pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
-    foreach (['Physical','Ebook Calibre','PDFs'] as $def) {
+    foreach (['Physical','Ebook Calibre'] as $def) {
         $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$def]);
     }
 
@@ -26,7 +26,7 @@ $shelfList = [];
 try {
     $shelfList = $pdo->query('SELECT name FROM shelves ORDER BY name')->fetchAll(PDO::FETCH_COLUMN);
 } catch (PDOException $e) {
-    $shelfList = ['Ebook Calibre','Physical','PDFs'];
+    $shelfList = ['Ebook Calibre','Physical'];
 }
 $shelfName = isset($_GET['shelf']) ? trim((string)$_GET['shelf']) : '';
 if ($shelfName !== '' && !in_array($shelfName, $shelfList, true)) {

--- a/update_shelf.php
+++ b/update_shelf.php
@@ -8,7 +8,7 @@ $value = $_POST['value'] ?? '';
 
 $pdo = getDatabaseConnection();
 $pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
-$defaults = ['Physical', 'Ebook Calibre', 'PDFs'];
+$defaults = ['Physical', 'Ebook Calibre'];
 foreach ($defaults as $d) {
     $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (?)')->execute([$d]);
 }


### PR DESCRIPTION
## Summary
- stop creating the default `PDFs` shelf
- add a new `notes` single-value column
- document the notes column in the README

## Testing
- `php -l add_shelf.php`
- `php -l update_shelf.php`
- `php -l list_books.php`
- `php -l db.php`

------
https://chatgpt.com/codex/tasks/task_e_688a3270fdf083299df8a9ec5218cd34