### PR TITLE
Add docx file type support

### DIFF
--- a/db.php
+++ b/db.php
@@ -121,7 +121,7 @@ function bookHasFile(string $relativePath): bool {
             continue;
         }
         $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
-        if (in_array($ext, ['epub', 'mobi', 'azw3', 'txt', 'pdf'])) {
+        if (in_array($ext, ['epub', 'mobi', 'azw3', 'txt', 'pdf', 'docx'])) {
             return true;
         }
     }
@@ -134,7 +134,7 @@ function firstBookFile(string $relativePath): ?string {
     if (!is_dir($dir)) {
         return null;
     }
-    $files = glob($dir . '/*.{epub,mobi,azw3,pdf,txt, mobi}', GLOB_BRACE);
+    $files = glob($dir . '/*.{epub,mobi,azw3,pdf,txt,docx}', GLOB_BRACE);
     if ($files) {
         return substr($files[0], strlen($library) + 1);
     }

--- a/list_books.php
+++ b/list_books.php
@@ -81,7 +81,7 @@ if ($statusName !== '' && !in_array($statusName, $statusOptions, true)) {
     $statusName = '';
 }
 $fileType = isset($_GET['filetype']) ? strtolower(trim((string)$_GET['filetype'])) : '';
-$allowedFileTypes = ['epub','mobi','azw3','txt','pdf','none'];
+$allowedFileTypes = ['epub','mobi','azw3','txt','pdf','docx','none'];
 if ($fileType !== '' && !in_array($fileType, $allowedFileTypes, true)) {
     $fileType = '';
 }
@@ -135,7 +135,7 @@ if ($shelfName !== '') {
 }
 if ($fileType !== '') {
     if ($fileType === 'none') {
-        $whereClauses[] = "NOT EXISTS (SELECT 1 FROM data d WHERE d.book = b.id AND lower(d.format) IN ('epub','mobi','azw3','txt','pdf'))";
+        $whereClauses[] = "NOT EXISTS (SELECT 1 FROM data d WHERE d.book = b.id AND lower(d.format) IN ('epub','mobi','azw3','txt','pdf','docx'))";
     } else {
         $whereClauses[] = 'EXISTS (SELECT 1 FROM data d WHERE d.book = b.id AND lower(d.format) = :file_type)';
         $params[':file_type'] = $fileType;
@@ -707,7 +707,7 @@ function linkTextColor(string $current, string $compare): string {
                 <li class="list-group-item<?= linkActive($fileType, '') ?>">
                     <a href="<?= htmlspecialchars($ftBase) ?>" class="stretched-link text-decoration-none<?= linkTextColor($fileType, '') ?>">All Types</a>
                 </li>
-                <?php foreach (['epub','mobi','azw3','txt','pdf','none'] as $ft): ?>
+                <?php foreach (['epub','mobi','azw3','txt','pdf','docx','none'] as $ft): ?>
                     <?php $url = buildBaseUrl(['filetype' => $ft]); ?>
                     <li class="list-group-item<?= linkActive($fileType, $ft) ?>">
                         <a href="<?= htmlspecialchars($url) ?>" class="stretched-link text-decoration-none<?= linkTextColor($fileType, $ft) ?>"><?= htmlspecialchars(strtoupper($ft)) ?></a>


### PR DESCRIPTION
## Summary
- add `docx` to allowed file types in list view
- recognise `docx` in database helpers

## Testing
- `php -l list_books.php`
- `php -l db.php`
- `php test_custom_columns.php` *(fails: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_688a6aafd6288329b3b47cd9a9a63fa3