### PR TITLE
Add notes button in book list

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -464,6 +464,9 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                                 data-search="<?= htmlspecialchars($book['title'] . ' ' . $book['authors'], ENT_QUOTES) ?>">
                             Metadata Google
                         </button>
+                        <a class="btn btn-sm btn-primary me-1" href="notes.php?id=<?= urlencode($book['id']) ?>">
+                            Notes
+                        </a>
                         <button type="button" class="btn btn-sm btn-danger delete-book"
                                 data-book-id="<?= htmlspecialchars($book['id']) ?>">
                             Delete


### PR DESCRIPTION
## Summary
- add a link from each book row to `notes.php` for editing notes

## Testing
- `php -l list_books.php`
- `php -l notes.php`


------
https://chatgpt.com/codex/tasks/task_e_688a703f5f24832990ba127ed719c6c3