### PR TITLE
Add notepad table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Each book also has a "Shelf" value stored in the custom column labeled `#shelf`.
 
 Books can now store freeform notes in the single-value custom column labeled `#notes`.
 
+Personal writing is kept in its own `notepad` table. This table is unrelated to
+any Calibre book and simply stores an `id`, `title`, the full `text`, the
+creation `time` and the `last_edited` timestamp. It is created automatically
+when the database is opened if it does not already exist.
+
 Genres are stored in the custom column labeled `genre` and listed in the sidebar. You can add,
 rename or delete genres from that list just like shelves and status values.
 

--- a/db.php
+++ b/db.php
@@ -188,6 +188,15 @@ function getDatabaseConnection(?string $path = null) {
 
 function initializeCustomColumns(PDO $pdo): void {
     try {
+        // 0. Ensure the notepad table for personal text entries
+        $pdo->exec("CREATE TABLE IF NOT EXISTS notepad (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            text TEXT NOT NULL,
+            time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            last_edited TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )");
+
         // 1. Ensure the shelves table (custom app table, not part of Calibre itself)
         $pdo->exec("CREATE TABLE IF NOT EXISTS shelves (name TEXT PRIMARY KEY)");
         foreach (['Physical', 'Ebook Calibre'] as $def) {

--- a/schema.sql
+++ b/schema.sql
@@ -792,3 +792,11 @@ CREATE VIEW tag_browser_filtered_custom_column_3 AS SELECT
                            books_list_filter(bl.book)) avg_rating,
                     value AS sort
                 FROM custom_column_3;
+
+CREATE TABLE notepad (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    text TEXT NOT NULL,
+    time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_edited TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- create a `notepad` table on startup
- document the notepad table in README
- include the table in `schema.sql`

## Testing
- `php -l db.php`

------
https://chatgpt.com/codex/tasks/task_e_688a9609b5b483299534a1662379757b