### PR TITLE
Enhance notepad page with deletions and book notes list

### DIFF
--- a/delete_note.php
+++ b/delete_note.php
@@ -1,0 +1,21 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+requireLogin();
+
+$noteId = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if ($noteId <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid note id']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $stmt = $pdo->prepare('DELETE FROM notepad WHERE id = ?');
+    $stmt->execute([$noteId]);
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- allow deleting personal notes from the Notepad list
- display a list of books that have notes and link to edit them
- enable note deletion through new `delete_note.php` endpoint

## Testing
- `php -l notepad.php`
- `php -l delete_note.php`


------
https://chatgpt.com/codex/tasks/task_e_688aa82ab1208329a1e73a52ab5a04f2