### PR TITLE
Fix list_books scroll restoration

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -116,7 +116,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const googleModal = new bootstrap.Modal(googleModalEl);
   const bookList = document.getElementById('book-list');
   initCoverDimensions();
-  updateLastVisible();
 
   const restoreId = sessionStorage.getItem('listBooksLastId');
   const restoreIndex = parseInt(sessionStorage.getItem('listBooksLastIndex') || '0', 10);
@@ -129,7 +128,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       sessionStorage.removeItem('listBooksLastId');
       sessionStorage.removeItem('listBooksLastIndex');
+      updateLastVisible();
     });
+  } else {
+    updateLastVisible();
   }
 
   async function loadMore() {


### PR DESCRIPTION
## Summary
- avoid overwriting scroll position before restoration
- update last visible book only after optional loadMoreUntil

## Testing
- `node --check js/list_books.js`


------
https://chatgpt.com/codex/tasks/task_e_688e5370e18c832981a5a8d4eed79767