### PR TITLE
Remove Clusterize.js dependency

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -106,12 +106,10 @@ document.addEventListener('DOMContentLoaded', () => {
   let allItems = Array.from(contentArea.children).map(el => el.outerHTML);
   let partialMode = false;
 
-  const clusterize = new Clusterize({
-    rows: allItems,
-    scrollId: 'scrollArea',
-    contentId: 'contentArea',
-    callbacks: { clusterChanged: () => initCoverDimensions(contentArea) }
-  });
+  function renderRows() {
+    contentArea.innerHTML = allItems.join('');
+    initCoverDimensions(contentArea);
+  }
 
   initCoverDimensions(contentArea);
 
@@ -144,7 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
     allItems = rows;
-    clusterize.update(allItems);
+    renderRows();
     calcItemHeight();
     currentPage = endPage;
   }
@@ -155,7 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.removeItem('lastItemIndex');
     const els = await fetchPage(1);
     allItems = els.map(el => el.outerHTML);
-    clusterize.update(allItems);
+    renderRows();
     calcItemHeight();
     currentPage = 1;
     scrollArea.scrollTop = 0;
@@ -166,7 +164,7 @@ document.addEventListener('DOMContentLoaded', () => {
     noticeBar.classList.add('d-none');
     const els = await fetchPage(1);
     allItems = els.map(el => el.outerHTML);
-    clusterize.update(allItems);
+    renderRows();
     calcItemHeight();
     currentPage = 1;
     await loadMoreUntil(index);
@@ -196,7 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
       tmp.innerHTML = html;
       const newRows = Array.from(tmp.children).map(el => el.outerHTML);
       allItems = allItems.concat(newRows);
-      clusterize.update(allItems);
+      renderRows();
       calcItemHeight();
       currentPage++;
     } catch (err) {

--- a/list_books.php
+++ b/list_books.php
@@ -874,8 +874,8 @@ if (count($breadcrumbs) === 1) {
             <!-- Main Content -->
 <div class="col-md-12">
   <div id="restoreNotice" class="alert alert-info d-none"></div>
-  <div id="scrollArea" class="clusterize-scroll" style="max-height:80vh; overflow-y:auto;">
-    <div id="contentArea" class="clusterize-content">
+  <div id="scrollArea" style="max-height:80vh; overflow-y:auto;">
+    <div id="contentArea">
       <?php render_book_rows($books, $shelfList, $statusOptions, $genreList, $sort, $authorId, $seriesId, $offset); ?>
     </div>
   </div>
@@ -903,7 +903,6 @@ if (count($breadcrumbs) === 1) {
     
     
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/clusterize.js@0.18.1/clusterize.min.js"></script>
 <script src="js/list_books.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Drop Clusterize.js from book list view
- Render book rows directly without external library

## Testing
- `php -l list_books.php`
- `node --check js/list_books.js`


------
https://chatgpt.com/codex/tasks/task_e_688e8db7d268832984fb5b04f0a4609d