### PR TITLE
Remove page parameter from sort links

### DIFF
--- a/navbar.php
+++ b/navbar.php
@@ -67,7 +67,6 @@ $statusNameVal = isset($statusName) ? $statusName : '';
 
         <!-- Sort Form -->
         <form class="d-flex" method="get" action="<?= htmlspecialchars($action) ?>">
-          <input type="hidden" name="page" value="1">
           <?php if ($searchVal !== ''): ?><input type="hidden" name="search" value="<?= htmlspecialchars($searchVal) ?>"><?php endif; ?>
           <?php if ($authorIdVal): ?><input type="hidden" name="author_id" value="<?= htmlspecialchars($authorIdVal) ?>"><?php endif; ?>
           <?php if ($seriesIdVal): ?><input type="hidden" name="series_id" value="<?= htmlspecialchars($seriesIdVal) ?>"><?php endif; ?>


### PR DESCRIPTION
## Summary
- Remove hidden `page` input from sort form so sorting no longer appends `?page=` to URLs

## Testing
- `php -l navbar.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_688e9d29cf9483298b833f8c59fcd07c