### PR TITLE
Enable infinite scrolling in book list

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -874,28 +874,10 @@ if (count($breadcrumbs) === 1) {
             <!-- Main Content -->
 <div class="col-md-12">
   <div id="contentArea">
+      <div id="topSentinel"></div>
       <?php render_book_rows($books, $shelfList, $statusOptions, $genreList, $sort, $authorId, $seriesId, $offset); ?>
+      <div id="bottomSentinel"></div>
   </div>
-
-  <nav id="paginationNav" aria-label="Page navigation" class="mt-3">
-    <ul class="pagination justify-content-center">
-      <li class="page-item <?= $page <= 1 ? 'disabled' : '' ?>">
-        <a class="page-link prev-page" href="<?= htmlspecialchars($baseUrl . max(1, $page - 1)) ?>">Previous</a>
-      </li>
-      <li class="page-item disabled">
-        <span class="page-link page-info">Page <?= $page ?> of <?= $totalPages ?></span>
-      </li>
-      <li class="page-item <?= $page >= $totalPages ? 'disabled' : '' ?>">
-        <a class="page-link next-page" href="<?= htmlspecialchars($baseUrl . min($totalPages, $page + 1)) ?>">Next</a>
-      </li>
-    </ul>
-  </nav>
-
-  <?php if ($page < $totalPages): ?>
-  <div class="d-grid my-3">
-    <button id="loadMoreBtn" class="btn btn-primary">Load More</button>
-  </div>
-  <?php endif; ?>
 </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add top and bottom sentinels to book list and remove manual pagination controls
- Implement JavaScript intersection observers to auto-fetch next and previous pages as user scrolls

## Testing
- `php -l list_books.php`
- `node --check js/list_books.js`


------
https://chatgpt.com/codex/tasks/task_e_688ea2a3293483298893fbb77a19d5d7