### PR TITLE
Reset list view position when using Back to Top

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -913,7 +913,14 @@ if (count($breadcrumbs) === 1) {
         });
         btn.addEventListener('click', e => {
             e.preventDefault();
-            window.scrollTo({ top: 0, behavior: 'smooth' });
+            if (window.listBooksSkipSave) {
+                window.listBooksSkipSave();
+            }
+            sessionStorage.removeItem('lastItem');
+            const params = new URLSearchParams(window.location.search);
+            params.delete('page');
+            const url = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+            window.location.href = url;
         });
     });
     </script>


### PR DESCRIPTION
## Summary
- Persist list position using `lastItem` and item IDs so returning users jump back to their previous spot
- Clicking "Back to Top" clears saved position and reloads page one

## Testing
- `php -l list_books.php`
- `node --check js/list_books.js && echo "JS OK"`


------
https://chatgpt.com/codex/tasks/task_e_688ea9b6c2588329acf5bf9c586c8212