### PR TITLE
Fix infinite scroll ignoring author initial filter

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -334,6 +334,9 @@ if ($fileType !== '') {
 if ($search !== '') {
     $baseUrl .= '&search=' . urlencode($search);
 }
+if ($authorInitial !== '') {
+    $baseUrl .= '&author_initial=' . urlencode($authorInitial);
+}
 $baseUrl .= '&page=';
 
 function render_book_rows(array $books, array $shelfList, array $statusOptions, array $genreList, string $sort, ?int $authorId, ?int $seriesId, int $offset = 0): void {


### PR DESCRIPTION
## Summary
- Preserve selected author initial in paging URL so infinite scroll stops after last matching author

## Testing
- `php -l list_books.php`
- `node --check js/list_books.js`


------
https://chatgpt.com/codex/tasks/task_e_688eb75b9ae88329bc9637d9c9b06449