### PR TITLE
Aggregate author and genre joins for book list query

### DIFF
--- a/db.php
+++ b/db.php
@@ -191,6 +191,18 @@ function getDatabaseConnection(?string $path = null) {
         }, 0);
 
         initializeCustomColumns($pdo);
+
+        // Ensure indexes used by book list queries
+        try {
+            $pdo->exec('CREATE INDEX IF NOT EXISTS books_authors_link_bidx ON books_authors_link (book)');
+            $genreId = (int)$pdo->query("SELECT id FROM custom_columns WHERE label = 'genre'")->fetchColumn();
+            if ($genreId) {
+                $pdo->exec("CREATE INDEX IF NOT EXISTS books_custom_column_{$genreId}_link_bidx ON books_custom_column_{$genreId}_link (book)");
+            }
+        } catch (PDOException $e) {
+            error_log('Index creation failed: ' . $e->getMessage());
+        }
+
         initializeFts($pdo);
 
         return $pdo;


### PR DESCRIPTION
## Summary
- Refactor book list query to join author and genre links once, aggregating results with `GROUP_CONCAT`.
- Create indexes on `books_authors_link.book` and the genre link table to support the new join strategy.
- Update `render_book_rows` to parse aggregated author and genre fields.

## Testing
- `php -l list_books.php`
- `php -l db.php`

------
https://chatgpt.com/codex/tasks/task_e_688f1f60908c8329b2c6c893d3250d6b