### PR TITLE
Handle database connection errors gracefully

### DIFF
--- a/api/books.php
+++ b/api/books.php
@@ -3,7 +3,13 @@ require_once '../db.php';
 requireLogin();
 header('Content-Type: application/json');
 
-$pdo = getDatabaseConnection();
+try {
+    $pdo = getDatabaseConnection(null, true);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Connection failed: ' . $e->getMessage()]);
+    exit;
+}
 
 // Locate custom columns
 $genreColumnId = (int)$pdo->query("SELECT id FROM custom_columns WHERE label = 'genre'")->fetchColumn();

--- a/db.php
+++ b/db.php
@@ -147,7 +147,7 @@ function firstBookFile(string $relativePath): ?string {
     return null;
 }
 
-function getDatabaseConnection(?string $path = null) {
+function getDatabaseConnection(?string $path = null, bool $throw = false) {
     $path = $path ?? currentDatabasePath();
     try {
         $pdo = new PDO('sqlite:' . $path);
@@ -207,6 +207,9 @@ function getDatabaseConnection(?string $path = null) {
 
         return $pdo;
     } catch (PDOException $e) {
+        if ($throw) {
+            throw $e;
+        }
         die('Connection failed: ' . $e->getMessage());
     }
 }

--- a/js/list_books.js
+++ b/js/list_books.js
@@ -223,7 +223,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function fetchPage(p) {
     const res = await fetch(fetchUrlBase + p);
-    return res.json();
+    const text = await res.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch (err) {
+      throw new Error(`Invalid JSON: ${text}`);
+    }
+    if (!res.ok || data.error) {
+      throw new Error(data.error || `HTTP ${res.status}`);
+    }
+    return data;
   }
 
   async function loadNext() {


### PR DESCRIPTION
## Summary
- Allow callers to request `getDatabaseConnection` to throw instead of exiting, enabling API error handling
- Return JSON error responses from `api/books.php` when the database connection fails
- Harden `fetchPage` in `list_books.js` to validate server responses and surface API errors

## Testing
- `php -l db.php`
- `php -l api/books.php`
- `node --check js/list_books.js`


------
https://chatgpt.com/codex/tasks/task_e_688f2608aa608329aa80a5f07a3ebd44