### PR TITLE
fix: handle non-string values in escapeHTML

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -1,4 +1,5 @@
 function escapeHTML(str) {
+  str = str === null || str === undefined ? '' : String(str);
   return str.replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')


### PR DESCRIPTION
## Summary
- guard escapeHTML against null or undefined values
- avoid runtime TypeError when data contains numbers

## Testing
- `node --check js/list_books.js`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f2917dcf883298cc3ae8fda05e1c2