### PR TITLE
Optimize cover dimension loading and lazy-load thumbnails

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -29,23 +29,26 @@ function setDescription(el, text) {
   el.innerHTML = html;
 }
 
-function initCoverDimensions(root = document) {
-  root.querySelectorAll('.cover-wrapper img.book-cover').forEach(img => {
-    const label = img.parentElement.querySelector('.cover-dimensions');
-    if (!label) return;
-    const update = () => {
-      if (img.naturalWidth && img.naturalHeight) {
-        label.textContent = `${img.naturalWidth} × ${img.naturalHeight}px`;
+function initCoverDimensions(scope = document) {
+  const roots = scope instanceof Node ? [scope] : Array.from(scope);
+  roots.forEach(root => {
+    root.querySelectorAll('.cover-wrapper img.book-cover').forEach(img => {
+      const label = img.parentElement.querySelector('.cover-dimensions');
+      if (!label) return;
+      const update = () => {
+        if (img.naturalWidth && img.naturalHeight) {
+          label.textContent = `${img.naturalWidth} × ${img.naturalHeight}px`;
+        } else {
+          label.textContent = 'No image data';
+        }
+      };
+      if (img.complete) {
+        update();
       } else {
-        label.textContent = 'No image data';
+        img.addEventListener('load', update, { once: true });
+        img.addEventListener('error', () => { label.textContent = 'Image not found'; }, { once: true });
       }
-    };
-    if (img.complete) {
-      update();
-    } else {
-      img.addEventListener('load', update, { once: true });
-      img.addEventListener('error', () => { label.textContent = 'Image not found'; }, { once: true });
-    }
+    });
   });
 }
 
@@ -116,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const els = await fetchPage(highestPage + 1);
       els.forEach(el => contentArea.insertBefore(el, bottomSentinel));
-      initCoverDimensions(contentArea);
+      initCoverDimensions(els);
       highestPage++;
     } catch (err) {
       console.error(err);
@@ -131,7 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const frag = document.createDocumentFragment();
       els.forEach(el => frag.appendChild(el));
       contentArea.insertBefore(frag, topSentinel.nextSibling);
-      initCoverDimensions(contentArea);
+      initCoverDimensions(els);
       const newHeight = document.body.scrollHeight;
       window.scrollBy(0, newHeight - prevHeight);
       lowestPage--;

--- a/list_books.php
+++ b/list_books.php
@@ -317,6 +317,7 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                             <img id="coverImage<?= (int)$book['id'] ?>" src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>"
                                  alt="Cover"
                                  class="img-thumbnail img-fluid book-cover"
+                                 loading="lazy"
                                  style="width: 100%; max-width:150px; height:auto;">
                             <div id="coverDimensions<?= (int)$book['id'] ?>" class="cover-dimensions position-absolute bottom-0 end-0 bg-dark text-white px-2 py-1 small rounded-top-start opacity-75" style="font-size: 0.8rem;">Loading...</div>
                         </div>


### PR DESCRIPTION
## Summary
- process cover dimensions only for newly fetched elements
- load next/previous pages without rescanning existing content
- lazy-load cover thumbnails in book list

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `php -l list_books.php`
- `node --check js/list_books.js`

------
https://chatgpt.com/codex/tasks/task_e_688f2de2c7348329b22546dcab62b4ff