### PR TITLE
Lazy load book covers

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -314,7 +314,9 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                 <?php if (!empty($book['has_cover'])): ?>
                     <a href="book.php?id=<?= urlencode($book['id']) ?>">
                         <div class="position-relative d-inline-block">
-                            <img id="coverImage<?= (int)$book['id'] ?>" src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>"
+                            <img id="coverImage<?= (int)$book['id'] ?>"
+                                 data-src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>"
+                                 src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
                                  alt="Cover"
                                  class="img-thumbnail img-fluid book-cover"
                                  loading="lazy"


### PR DESCRIPTION
## Summary
- Defer book cover downloads by swapping `src` for a placeholder and storing the real path in `data-src`
- Use an IntersectionObserver to load images only when book cards scroll into view, including for newly fetched pages

## Testing
- `php -l list_books.php`
- `node --check js/list_books.js`


------
https://chatgpt.com/codex/tasks/task_e_688f2fb9526c83299bd11bbbe7b6b702