### PR TITLE
Fix scroll jump caused by trimming pages in infinite list

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -227,7 +227,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (i >= start && i < end) item.remove();
       });
       const newHeight = document.body.scrollHeight;
-      window.scrollBy(0, newHeight - prevHeight);
+      // When removing items from the top, the browser automatically adjusts the
+      // scroll position upward by the height of the removed content. We need to
+      // compensate by scrolling back down by that difference so that the user
+      // remains at the same logical position in the list.
+      window.scrollBy(0, prevHeight - newHeight);
       lowestPage++;
     }
 


### PR DESCRIPTION
## Summary
- fix scroll position when removing older pages during infinite scroll
- avoid unwanted jump and hash updates when scrolling

## Testing
- `node -c js/list_books.js`

------
https://chatgpt.com/codex/tasks/task_e_688f3b2a06088329bd1bd1f4ba7997d7