### PR TITLE
Prevent scroll jumps when trimming book list

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -218,6 +218,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const minPage = Math.max(1, currentPage - 2);
     const maxPage = Math.min(totalPages, currentPage + 2);
 
+    // Modifying the DOM while intersection observers are active can trigger
+    // unwanted page loads, causing the viewport to jump around. Temporarily
+    // stop observing the sentinels so trimming doesn't fire additional fetches.
+    topObserver.unobserve(topSentinel);
+    bottomObserver.unobserve(bottomSentinel);
+
     while (lowestPage < minPage) {
       const start = (lowestPage - 1) * perPage;
       const end = start + perPage;
@@ -244,6 +250,10 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       highestPage--;
     }
+
+    // Resume observing now that DOM adjustments are complete.
+    bottomObserver.observe(bottomSentinel);
+    topObserver.observe(topSentinel);
 
     prefetchNext();
     prefetchPrevious();


### PR DESCRIPTION
## Summary
- Temporarily disable IntersectionObservers while removing off-screen pages
- Re-enable observers after trim to avoid unexpected page loads

## Testing
- `node --check js/list_books.js && echo "Syntax OK"`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_688f3d21300c8329aa5d8ac2821cb7f6