### PR TITLE
Add Amazon metadata search front-end

### DIFF
--- a/metadata/amazon.html
+++ b/metadata/amazon.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Amazon Metadata Search</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <script src="../js/theme.js"></script>
+</head>
+<body class="pt-5">
+<div class="container">
+    <h1 class="mb-4">Amazon Metadata Search</h1>
+    <form id="search-form" class="mb-3">
+        <div class="input-group">
+            <input type="text" id="query" class="form-control" placeholder="Search for books">
+            <button class="btn btn-primary" type="submit">Search</button>
+        </div>
+    </form>
+    <div id="results"></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script>
+const form = document.getElementById('search-form');
+const resultsDiv = document.getElementById('results');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const q = document.getElementById('query').value.trim();
+    if (!q) return;
+    resultsDiv.innerHTML = '<p>Loading...</p>';
+    try {
+        const resp = await fetch('amazon.php?q=' + encodeURIComponent(q));
+        const data = await resp.json();
+        if (!Array.isArray(data) || data.length === 0) {
+            resultsDiv.innerHTML = '<p>No results found.</p>';
+            return;
+        }
+        resultsDiv.innerHTML = '';
+        data.forEach(book => {
+            const div = document.createElement('div');
+            div.className = 'card mb-3';
+            div.innerHTML = `
+                ${book.cover ? `<img src="${book.cover}" class="card-img-top" alt="Cover">` : ''}
+                <div class="card-body">
+                    <h5 class="card-title">${book.title}</h5>
+                    <h6 class="card-subtitle mb-2 text-muted">${book.authors.join(', ')}</h6>
+                    <p class="card-text">${book.description}</p>
+                    <p class="card-text"><small class="text-muted">Rating: ${book.rating}</small></p>
+                    <a href="${book.url}" class="card-link" target="_blank">View on Amazon</a>
+                </div>
+            `;
+            resultsDiv.appendChild(div);
+        });
+    } catch (err) {
+        resultsDiv.innerHTML = '<p class="text-danger">Error fetching results.</p>';
+    }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Bootstrap-based front end to query `metadata/amazon.php`

## Testing
- `php -l metadata/amazon.php`


------
https://chatgpt.com/codex/tasks/task_e_688ff8caffe483299e5bd8a6f4c3a321