### PR TITLE
Add metadata aggregator endpoint

### DIFF
--- a/metadata/metadata.php
+++ b/metadata/metadata.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/metadata_sources.php';
+
+header('Content-Type: application/json');
+$query = isset($_GET['q']) ? trim($_GET['q']) : '';
+if ($query === '') {
+    echo json_encode([]);
+    exit;
+}
+
+$results = [];
+$functions = get_defined_functions();
+foreach ($functions['user'] as $fn) {
+    if (strpos($fn, 'search_') !== 0) {
+        continue;
+    }
+    try {
+        $sourceResults = call_user_func($fn, $query);
+        if (!is_array($sourceResults)) {
+            $sourceResults = [];
+        }
+    } catch (Throwable $e) {
+        $sourceResults = [];
+    }
+    $source = substr($fn, strlen('search_'));
+    foreach ($sourceResults as &$item) {
+        if (!isset($item['source'])) {
+            $item['source'] = $source;
+        }
+    }
+    unset($item);
+    $results = array_merge($results, $sourceResults);
+}
+
+echo json_encode($results, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
## Summary
- add `metadata/metadata.php` endpoint to query all metadata sources and merge results

## Testing
- `php -l metadata/metadata.php`
- `php -r '$_GET["q"]="harry potter"; include "metadata/metadata.php";' > /tmp/metadata_output.json`
- `head -c 400 /tmp/metadata_output.json`


------
https://chatgpt.com/codex/tasks/task_e_6890809eae708329abb2b616633e4a11