### PR TITLE
Show metadata cover dimensions and tune search sources

### DIFF
--- a/js/book.js
+++ b/js/book.js
@@ -146,7 +146,10 @@ document.addEventListener('DOMContentLoaded', () => {
             html += `<h5 class="mt-3">${escapeHTML(src.replace(/_/g, ' '))}</h5>`;
             for (const it of arr) {
               html += '<div class="mb-3">';
-              if (it.cover) html += `<img src="${escapeHTML(it.cover)}" style="height:100px" class="me-2 mb-2">`;
+              if (it.cover) {
+                html += `<img src="${escapeHTML(it.cover)}" style="height:100px" class="me-2 mb-1 meta-cover">`;
+                html += '<div class="text-muted small mb-2 meta-cover-dim"></div>';
+              }
               html += `<strong>${escapeHTML(it.title || '')}</strong>`;
               if (it.authors) html += ' by ' + escapeHTML(it.authors);
               if (it.year) html += ` (${escapeHTML(String(it.year))})`;
@@ -159,6 +162,22 @@ document.addEventListener('DOMContentLoaded', () => {
             }
           }
           metadataResults.innerHTML = html;
+          metadataResults.querySelectorAll('.meta-cover').forEach(imgEl => {
+            const dimEl = imgEl.nextElementSibling;
+            function setDim() {
+              if (dimEl) {
+                dimEl.textContent = `${imgEl.naturalWidth} × ${imgEl.naturalHeight}px`;
+              }
+            }
+            if (imgEl.complete) {
+              setDim();
+            } else {
+              imgEl.addEventListener('load', setDim, { once: true });
+            }
+            imgEl.addEventListener('error', () => {
+              if (dimEl) dimEl.textContent = 'Image not found';
+            }, { once: true });
+          });
         })
         .catch(() => { metadataResults.textContent = 'Error fetching results'; });
       if (metadataModal) {

--- a/metadata/metadata_sources.php
+++ b/metadata/metadata_sources.php
@@ -14,7 +14,7 @@ function search_annas_archive(string $query): array {
     }
 
     $url = 'https://annas-archive-api.p.rapidapi.com/search?q=' . urlencode($query)
-        . '&skip=0&limit=20&source=libgenLi,libgenRs,zLibrary,sciHub';
+        . '&skip=0&limit=5&source=libgenLi,libgenRs,zLibrary,sciHub';
 
     $curl = curl_init();
     curl_setopt_array($curl, [
@@ -43,7 +43,7 @@ function search_annas_archive(string $query): array {
     }
 
     $results = [];
-    foreach ($data['books'] as $book) {
+    foreach (array_slice($data['books'], 0, 5) as $book) {
         $md5 = $book['md5'] ?? '';
         $results[] = [
             'title' => $book['title'] ?? '',
@@ -75,7 +75,7 @@ function search_google_books(string $query): array {
     }
 
     $url = 'https://www.googleapis.com/books/v1/volumes?q=' . urlencode($query)
-        . '&maxResults=20&key=' . urlencode($apiKey);
+        . '&maxResults=20&langRestrict=en&key=' . urlencode($apiKey);
     $ch = curl_init($url);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,


### PR DESCRIPTION
## Summary
- display scraped cover image dimensions in the book metadata modal
- limit Anna's Archive metadata results to five
- restrict Google Books metadata results to English where available

## Testing
- `php -l metadata/metadata_sources.php`
- `node --check js/book.js`


------
https://chatgpt.com/codex/tasks/task_e_68908e9ef8c4832998d396b240e7df1d