### PR TITLE
Use Amazon for book metadata

### DIFF
--- a/amazon_search.php
+++ b/amazon_search.php
@@ -1,0 +1,12 @@
+<?php
+header('Content-Type: application/json');
+require_once __DIR__ . '/metadata/metadata_sources.php';
+
+$q = trim($_GET['q'] ?? '');
+if ($q === '') {
+    echo json_encode(['books' => []]);
+    exit;
+}
+
+$books = search_amazon_books($q);
+echo json_encode(['books' => $books]);

--- a/js/list_books.js
+++ b/js/list_books.js
@@ -90,8 +90,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (pageNav) {
     pageNav.classList.add('d-none');
   }
-  const googleModalEl = document.getElementById('googleModal');
-  const googleModal = new bootstrap.Modal(googleModalEl);
+  const amazonModalEl = document.getElementById('amazonModal');
+  const amazonModal = new bootstrap.Modal(amazonModalEl);
 
   initCoverDimensions(contentArea);
 
@@ -543,15 +543,15 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.addEventListener('click', async ev => {
-    const metaBtn = ev.target.closest('.google-meta');
-    const resultsEl = document.getElementById('googleResults');
+    const metaBtn = ev.target.closest('.amazon-meta');
+    const resultsEl = document.getElementById('amazonResults');
     if (metaBtn) {
       const bookId = metaBtn.dataset.bookId;
       const query = metaBtn.dataset.search;
       if (resultsEl) resultsEl.textContent = 'Loading...';
-      googleModal.show();
+      amazonModal.show();
       try {
-        fetch(`google_search.php?q=${encodeURIComponent(query)}`)
+        fetch(`amazon_search.php?q=${encodeURIComponent(query)}`)
           .then(response => response.json())
           .then(data => {
             if (!data.books || data.books.length === 0) {
@@ -560,9 +560,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             const resultsHTML = data.books.map(b => {
               const title = escapeHTML(b.title || '');
-              const author = escapeHTML(b.author || '');
+              const author = escapeHTML(b.authors || '');
               const year = escapeHTML(b.year || '');
-              const imgUrl = escapeHTML(b.imgUrl || '');
+              const imgUrl = escapeHTML(b.cover || '');
               const description = escapeHTML(b.description || '');
               return `
                         <div class="mb-3 p-2 border rounded bg-light">
@@ -572,7 +572,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             ${year ? ` (${year})` : ''}
                             ${description ? `<br><em>${description}</em>` : ''}
                             <div>
-                                <button type="button" class="btn btn-sm btn-primary mt-2 google-use"
+                                <button type="button" class="btn btn-sm btn-primary mt-2 amazon-use"
                                     data-book-id="${bookId}"
                                     data-title="${title.replace(/"/g, '&quot;')}"
                                     data-authors="${author.replace(/"/g, '&quot;')}"
@@ -597,7 +597,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       return;
     }
-    const useBtn = ev.target.closest('.google-use');
+    const useBtn = ev.target.closest('.amazon-use');
     if (!useBtn) return;
     const bookId = useBtn.dataset.bookId;
     const t = useBtn.dataset.title;
@@ -613,7 +613,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       const data = await response.json();
       if (data.status === 'ok') {
-        googleModal.hide();
+        amazonModal.hide();
         const bookBlock = document.querySelector(`[data-book-block-id="${bookId}"]`);
         if (bookBlock) {
           const titleEl = bookBlock.querySelector('.book-title');

--- a/list_books.php
+++ b/list_books.php
@@ -449,10 +449,10 @@ function render_book_rows(array $books, array $shelfList, array $statusOptions, 
                                 <?php
                             }
                         endif; ?>
-                        <button type="button" class="btn btn-sm btn-secondary google-meta me-1"
+                        <button type="button" class="btn btn-sm btn-secondary amazon-meta me-1"
                                 data-book-id="<?= htmlspecialchars($book['id']) ?>"
                                 data-search="<?= htmlspecialchars($book['title'] . ' ' . $book['authors'], ENT_QUOTES) ?>">
-                            Metadata Google
+                            Metadata Amazon
                         </button>
                         <a class="btn btn-sm btn-primary me-1" href="notes.php?id=<?= urlencode($book['id']) ?>">
                             Notes
@@ -877,16 +877,16 @@ body {
 </div>
         </div>
 
-    <!-- Google Books Metadata Modal -->
-    <div class="modal fade" id="googleModal" tabindex="-1" aria-hidden="true">
+    <!-- Amazon Metadata Modal -->
+    <div class="modal fade" id="amazonModal" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
           <div class="modal-header">
-            <h5 class="modal-title">Google Books Results</h5>
+            <h5 class="modal-title">Amazon Results</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <div id="googleResults">Loading...</div>
+            <div id="amazonResults">Loading...</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Switch metadata lookup in book list to Amazon instead of Google
- Add backend route to query Amazon and populate metadata modal
- Update front-end to handle Amazon results and apply selected metadata to books

## Testing
- `php -l amazon_search.php`
- `php -l list_books.php`
- `node -c js/list_books.js && echo 'JS syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_689097d3846c83299b353b46a86dc2e0