### PR TITLE
Surface Amazon error codes in search responses

### DIFF
--- a/amazon_search.php
+++ b/amazon_search.php
@@ -8,5 +8,9 @@ if ($q === '') {
     exit;
 }
 
-$books = search_amazon_books($q);
-echo json_encode(['books' => $books]);
+$books = search_amazon_books($q, $error);
+$response = ['books' => $books];
+if ($error !== null) {
+    $response['error'] = $error;
+}
+echo json_encode($response);

--- a/metadata/amazon.php
+++ b/metadata/amazon.php
@@ -8,6 +8,10 @@ if ($query === '') {
     exit;
 }
 
-$results = search_amazon_books($query);
-echo json_encode($results, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+$results = search_amazon_books($query, $error);
+$response = ['books' => $results];
+if ($error !== null) {
+    $response['error'] = $error;
+}
+echo json_encode($response, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
 ?>


### PR DESCRIPTION
## Summary
- capture cURL, HTTP, and Cloudflare errors when scraping Amazon
- bubble error details through `search_amazon_books`
- include any Amazon error information in JSON responses

## Testing
- `php -l metadata/metadata_sources.php`
- `php -l amazon_search.php`
- `php -l metadata/amazon.php`
- `php -r '$_GET["q"]="harry potter"; include "amazon_search.php";' 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6890a2021b788329a00b17f4cfff571a