### PR TITLE
Include series folder in send-to-device path

### DIFF
--- a/book.php
+++ b/book.php
@@ -357,7 +357,12 @@ if ($sendRequested) {
         if ($genreDir === '') { $genreDir = 'Unknown'; }
         $authorDir = safe_filename($author);
         if ($authorDir === '') { $authorDir = 'Unknown'; }
-        $remotePath = rtrim($remoteDir, '/') . '/' . $genreDir . '/' . $authorDir;
+        $seriesDir = '';
+        $series = trim($book['series'] ?? '');
+        if ($series !== '') {
+            $seriesDir = '/' . safe_filename($series);
+        }
+        $remotePath = rtrim($remoteDir, '/') . '/' . $genreDir . '/' . $authorDir . $seriesDir;
 
         $localFile = getLibraryPath() . '/' . $ebookFileRel;
         $baseName  = basename($ebookFileRel);


### PR DESCRIPTION
## Summary
- ensure send-to-device script creates series subdirectories when present

## Testing
- `php -l book.php`


------
https://chatgpt.com/codex/tasks/task_e_689241ec4f088329b664566c78157195