### PR TITLE
Prefix series index in send-to-device filenames

### DIFF
--- a/book.php
+++ b/book.php
@@ -370,6 +370,20 @@ if ($sendRequested) {
         $ext       = pathinfo($baseName, PATHINFO_EXTENSION);
         $remoteFileName = safe_filename($nameOnly);
         if ($remoteFileName === '') { $remoteFileName = 'book'; }
+        if ($series !== '' && $book['series_index'] !== null && $book['series_index'] !== '') {
+            $seriesIdxStr = (string)$book['series_index'];
+            if (strpos($seriesIdxStr, '.') !== false) {
+                [$whole, $decimal] = explode('.', $seriesIdxStr, 2);
+                $seriesIdxStr = str_pad($whole, 2, '0', STR_PAD_LEFT);
+                $decimal = rtrim($decimal, '0');
+                if ($decimal !== '') {
+                    $seriesIdxStr .= '.' . $decimal;
+                }
+            } else {
+                $seriesIdxStr = str_pad($seriesIdxStr, 2, '0', STR_PAD_LEFT);
+            }
+            $remoteFileName = $seriesIdxStr . ' - ' . $remoteFileName;
+        }
         if ($ext !== '') { $remoteFileName .= '.' . $ext; }
 
         $identity  = '/home/david/.ssh/id_rsa';


### PR DESCRIPTION
## Summary
- Prepend series index to filenames when sending books to a device so series entries retain order

## Testing
- `php -l book.php`


------
https://chatgpt.com/codex/tasks/task_e_689249e4a63c83299714989732795c3b