### PR TITLE
Add custom column ID helper with caching

### DIFF
--- a/db.php
+++ b/db.php
@@ -147,6 +147,16 @@ function firstBookFile(string $relativePath): ?string {
     return null;
 }
 
+function getCustomColumnId(PDO $pdo, string $label): int {
+    static $cache = [];
+    if (!isset($cache[$label])) {
+        $stmt = $pdo->prepare('SELECT id FROM custom_columns WHERE label = ?');
+        $stmt->execute([$label]);
+        $cache[$label] = (int)$stmt->fetchColumn();
+    }
+    return $cache[$label];
+}
+
 function getDatabaseConnection(?string $path = null) {
     $path = $path ?? currentDatabasePath();
     try {
@@ -195,7 +205,7 @@ function getDatabaseConnection(?string $path = null) {
         // Ensure indexes used by book list queries
         try {
             $pdo->exec('CREATE INDEX IF NOT EXISTS books_authors_link_bidx ON books_authors_link (book)');
-            $genreId = (int)$pdo->query("SELECT id FROM custom_columns WHERE label = 'genre'")->fetchColumn();
+            $genreId = getCustomColumnId($pdo, 'genre');
             if ($genreId) {
                 $pdo->exec("CREATE INDEX IF NOT EXISTS books_custom_column_{$genreId}_link_bidx ON books_custom_column_{$genreId}_link (book)");
             }

--- a/list_books.php
+++ b/list_books.php
@@ -3,12 +3,12 @@ require_once 'db.php';
 requireLogin();
 
 $pdo = getDatabaseConnection();
-$genreColumnId = (int)$pdo->query("SELECT id FROM custom_columns WHERE label = 'genre'")->fetchColumn();
+$genreColumnId = getCustomColumnId($pdo, 'genre');
 $genreLinkTable = "books_custom_column_{$genreColumnId}_link";
 $totalLibraryBooks = (int)$pdo->query('SELECT COUNT(*) FROM books')->fetchColumn();
 
 // Shelf column and list with counts
-$shelfId = (int)$pdo->query("SELECT id FROM custom_columns WHERE label = 'shelf'")->fetchColumn();
+$shelfId = getCustomColumnId($pdo, 'shelf');
 $shelfValueTable = "custom_column_{$shelfId}";
 $shelfLinkTable  = "books_custom_column_{$shelfId}_link";
 $shelves = [];
@@ -32,7 +32,7 @@ if ($shelfName !== '' && !in_array($shelfName, $shelfList, true)) {
 }
 
 // Locate custom column for reading status and fetch counts
-$statusId = (int)$pdo->query("SELECT id FROM custom_columns WHERE label = 'status'")->fetchColumn();
+$statusId = getCustomColumnId($pdo, 'status');
 $statusTable = 'books_custom_column_' . $statusId . '_link';
 $statusIsLink = true;
 $statusList = [];
@@ -50,7 +50,7 @@ try {
 }
 $statusOptions = array_column($statusList, 'value');
 
-$recId = (int)$pdo->query("SELECT id FROM custom_columns WHERE label = 'recommendation'")->fetchColumn();
+$recId = getCustomColumnId($pdo, 'recommendation');
 $recTable = "custom_column_{$recId}";
 $recLinkTable = "books_custom_column_{$recId}_link";
 $recColumnExists = true;
@@ -62,7 +62,7 @@ $subseriesValueTable = '';
 $subseriesIndexColumn = null;
 
 try {
-    $subseriesColumnId = $pdo->query("SELECT id FROM custom_columns WHERE label = 'subseries'")->fetchColumn();
+    $subseriesColumnId = getCustomColumnId($pdo, 'subseries');
     if ($subseriesColumnId) {
         $hasSubseries = true;
         $subseriesIsCustom = true;


### PR DESCRIPTION
## Summary
- add `getCustomColumnId()` utility to centralize and cache custom column lookups
- refactor `list_books.php` to use the helper for genre, shelf, status, recommendation, and subseries columns
- use the helper when creating indexes during DB connection setup

## Testing
- `php -l db.php`
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_68932fb24684832993e938a22932ded7