### PR TITLE
Add disk cache for library lists and totals

### DIFF
--- a/add_genre.php
+++ b/add_genre.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $genre = trim($_POST['genre'] ?? '');
@@ -16,6 +17,7 @@ try {
     $valueTable = "custom_column_{$genreId}";
     $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
         ->execute([':val' => $genre]);
+    invalidateCache('genres');
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/add_shelf.php
+++ b/add_shelf.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $shelf = trim($_POST['shelf'] ?? '');
@@ -20,6 +21,7 @@ try {
     }
     $stmt = $pdo->prepare('INSERT OR IGNORE INTO shelves (name) VALUES (:name)');
     $stmt->execute([':name' => $shelf]);
+    invalidateCache('shelves');
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/add_status.php
+++ b/add_status.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $status = trim($_POST['status'] ?? '');
@@ -24,6 +25,7 @@ try {
     $valueTable = 'custom_column_' . (int)$statusId;
     $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
         ->execute([':val' => $status]);
+    invalidateCache('statuses');
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/cache.php
+++ b/cache.php
@@ -1,0 +1,112 @@
+<?php
+// Lightweight file-based cache utility
+// Stores JSON-encoded results with a TTL in the cache/ directory.
+
+const CACHE_DIR = __DIR__ . '/cache';
+const CACHE_TTL = 3600; // default TTL in seconds
+
+/**
+ * Fetch a value from cache or generate it using the callback.
+ *
+ * @param string   $key     Cache key (filename without extension)
+ * @param callable $create  Callback to generate the value if cache is missing or stale
+ * @param int      $ttl     Time to live in seconds
+ *
+ * @return mixed The cached or freshly generated value
+ */
+function getCachedData(string $key, callable $create, int $ttl = CACHE_TTL) {
+    $file = CACHE_DIR . '/' . $key . '.json';
+    if (is_file($file) && (time() - filemtime($file) < $ttl)) {
+        $data = json_decode((string)file_get_contents($file), true);
+        if ($data !== null) {
+            return $data;
+        }
+    }
+    $value = $create();
+    if (!is_dir(CACHE_DIR)) {
+        mkdir(CACHE_DIR, 0777, true);
+    }
+    file_put_contents($file, json_encode($value));
+    return $value;
+}
+
+/**
+ * Remove a cached file by key.
+ */
+function invalidateCache(string $key): void {
+    $file = CACHE_DIR . '/' . $key . '.json';
+    if (is_file($file)) {
+        unlink($file);
+    }
+}
+
+// Domain-specific helpers --------------------------------------------------
+
+/** Fetch shelves with book counts, cached. */
+function getCachedShelves(PDO $pdo, int $ttl = CACHE_TTL): array {
+    return getCachedData('shelves', function () use ($pdo) {
+        $shelfId = getCustomColumnId($pdo, 'shelf');
+        $shelfValueTable = "custom_column_{$shelfId}";
+        $shelfLinkTable  = "books_custom_column_{$shelfId}_link";
+        try {
+            $stmt = $pdo->query(
+                "SELECT s.name AS value, COUNT(bsl.book) AS book_count\n" .
+                "FROM shelves s\n" .
+                "LEFT JOIN $shelfValueTable sv ON sv.value = s.name\n" .
+                "LEFT JOIN $shelfLinkTable bsl ON bsl.value = sv.id\n" .
+                "GROUP BY s.name\n" .
+                "ORDER BY s.name"
+            );
+            return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } catch (PDOException $e) {
+            return [];
+        }
+    }, $ttl);
+}
+
+/** Fetch statuses with book counts, cached. */
+function getCachedStatuses(PDO $pdo, int $ttl = CACHE_TTL): array {
+    return getCachedData('statuses', function () use ($pdo) {
+        $statusId = getCustomColumnId($pdo, 'status');
+        $statusTable = 'books_custom_column_' . $statusId . '_link';
+        try {
+            $stmt = $pdo->query(
+                "SELECT cv.value, COUNT(sc.book) AS book_count\n" .
+                "FROM custom_column_{$statusId} cv\n" .
+                "LEFT JOIN $statusTable sc ON sc.value = cv.id\n" .
+                "GROUP BY cv.id\n" .
+                "ORDER BY cv.value COLLATE NOCASE"
+            );
+            return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } catch (PDOException $e) {
+            return [];
+        }
+    }, $ttl);
+}
+
+/** Fetch genres with book counts, cached. */
+function getCachedGenres(PDO $pdo, int $ttl = CACHE_TTL): array {
+    return getCachedData('genres', function () use ($pdo) {
+        $genreColumnId = getCustomColumnId($pdo, 'genre');
+        $genreLinkTable = "books_custom_column_{$genreColumnId}_link";
+        try {
+            $stmt = $pdo->query(
+                "SELECT gv.id, gv.value, COUNT(gl.book) AS book_count\n" .
+                "FROM custom_column_{$genreColumnId} gv\n" .
+                "LEFT JOIN $genreLinkTable gl ON gl.value = gv.id\n" .
+                "GROUP BY gv.id\n" .
+                "ORDER BY gv.value COLLATE NOCASE"
+            );
+            return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } catch (PDOException $e) {
+            return [];
+        }
+    }, $ttl);
+}
+
+/** Total number of books in the library, cached. */
+function getTotalLibraryBooks(PDO $pdo, int $ttl = CACHE_TTL): int {
+    return (int)getCachedData('total_books', function () use ($pdo) {
+        return (int)$pdo->query('SELECT COUNT(*) FROM books')->fetchColumn();
+    }, $ttl);
+}

--- a/delete_genre.php
+++ b/delete_genre.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $genre = trim($_POST['genre'] ?? '');
@@ -23,6 +24,7 @@ try {
         $pdo->prepare("DELETE FROM $linkTable WHERE value = :id")->execute([':id' => $gid]);
         $pdo->prepare("DELETE FROM $valueTable WHERE id = :id")->execute([':id' => $gid]);
     }
+    invalidateCache('genres');
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/delete_shelf.php
+++ b/delete_shelf.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $shelf = trim($_POST['shelf'] ?? '');
@@ -14,6 +15,7 @@ $pdo = getDatabaseConnection();
 try {
     $stmt = $pdo->prepare('DELETE FROM shelves WHERE name = :name');
     $stmt->execute([':name' => $shelf]);
+    invalidateCache('shelves');
     $shelfId = ensureSingleValueColumn($pdo, '#shelf', 'Shelf');
     $table = "custom_column_{$shelfId}";
 

--- a/delete_status.php
+++ b/delete_status.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $status = trim($_POST['status'] ?? '');
@@ -23,6 +24,7 @@ try {
         $pdo->prepare("DELETE FROM $linkTable WHERE value = :id")->execute([':id' => $sid]);
         $pdo->prepare("DELETE FROM $valueTable WHERE id = :id")->execute([':id' => $sid]);
     }
+    invalidateCache('statuses');
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     http_response_code(500);


### PR DESCRIPTION
## Summary
- add cache.php providing JSON file-based cache and helper fetchers for shelves, statuses, genres, and total book count
- use cached queries in list_books.php to avoid repeated COUNT and list lookups
- invalidate caches from shelf, status, and genre mutation endpoints to keep counts fresh

## Testing
- `php -l cache.php list_books.php add_genre.php delete_genre.php add_status.php delete_status.php add_shelf.php delete_shelf.php`


------
https://chatgpt.com/codex/tasks/task_e_689340cf9da4832980669f6403a41d47