### PR TITLE
Add indexes for book lookup tables

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -24,6 +24,8 @@ CREATE TABLE books_authors_link ( id INTEGER PRIMARY KEY,
                                           author INTEGER NOT NULL,
                                           UNIQUE(book, author)
                                         );
+CREATE INDEX IF NOT EXISTS idx_books_authors_link_book ON books_authors_link(book);
+CREATE INDEX IF NOT EXISTS idx_books_authors_link_author ON books_authors_link(author);
 CREATE TABLE books_languages_link ( id INTEGER PRIMARY KEY,
                                             book INTEGER NOT NULL,
                                             lang_code INTEGER NOT NULL,
@@ -50,6 +52,8 @@ CREATE TABLE books_series_link ( id INTEGER PRIMARY KEY,
                                           series INTEGER NOT NULL,
                                           UNIQUE(book)
                                         );
+CREATE INDEX IF NOT EXISTS idx_books_series_link_book ON books_series_link(book);
+CREATE INDEX IF NOT EXISTS idx_books_series_link_series ON books_series_link(series);
 CREATE TABLE books_tags_link ( id INTEGER PRIMARY KEY,
                                           book INTEGER NOT NULL,
                                           tag INTEGER NOT NULL,
@@ -659,8 +663,8 @@ CREATE TABLE books_custom_column_1_link(
                     
                     UNIQUE(book, value)
                     );
-CREATE INDEX books_custom_column_1_link_aidx ON books_custom_column_1_link (value);
-CREATE INDEX books_custom_column_1_link_bidx ON books_custom_column_1_link (book);
+CREATE INDEX IF NOT EXISTS idx_books_custom_column_1_link_value ON books_custom_column_1_link(value);
+CREATE INDEX IF NOT EXISTS idx_books_custom_column_1_link_book ON books_custom_column_1_link(book);
 CREATE TRIGGER fkc_update_books_custom_column_1_link_a
                         BEFORE UPDATE OF book ON books_custom_column_1_link
                         BEGIN
@@ -732,8 +736,8 @@ CREATE TABLE books_custom_column_3_link(
                     
                     UNIQUE(book, value)
                     );
-CREATE INDEX books_custom_column_3_link_aidx ON books_custom_column_3_link (value);
-CREATE INDEX books_custom_column_3_link_bidx ON books_custom_column_3_link (book);
+CREATE INDEX IF NOT EXISTS idx_books_custom_column_3_link_value ON books_custom_column_3_link(value);
+CREATE INDEX IF NOT EXISTS idx_books_custom_column_3_link_book ON books_custom_column_3_link(book);
 CREATE TRIGGER fkc_update_books_custom_column_3_link_a
                         BEFORE UPDATE OF book ON books_custom_column_3_link
                         BEGIN

--- a/scripts/init_schema.php
+++ b/scripts/init_schema.php
@@ -4,4 +4,21 @@ require_once __DIR__ . '/../db.php';
 $pdo = getDatabaseConnection();
 initializeCustomColumns($pdo);
 
+// Ensure indexes exist for common lookup tables
+try {
+    $pdo->exec('CREATE INDEX IF NOT EXISTS idx_books_authors_link_book ON books_authors_link(book)');
+    $pdo->exec('CREATE INDEX IF NOT EXISTS idx_books_authors_link_author ON books_authors_link(author)');
+    $pdo->exec('CREATE INDEX IF NOT EXISTS idx_books_series_link_book ON books_series_link(book)');
+    $pdo->exec('CREATE INDEX IF NOT EXISTS idx_books_series_link_series ON books_series_link(series)');
+
+    $stmt = $pdo->query('SELECT id FROM custom_columns');
+    while (($id = $stmt->fetchColumn()) !== false) {
+        $link = "books_custom_column_{$id}_link";
+        $pdo->exec("CREATE INDEX IF NOT EXISTS idx_{$link}_book ON {$link}(book)");
+        $pdo->exec("CREATE INDEX IF NOT EXISTS idx_{$link}_value ON {$link}(value)");
+    }
+} catch (PDOException $e) {
+    error_log('Index creation failed: ' . $e->getMessage());
+}
+
 echo "Schema initialized\n";


### PR DESCRIPTION
## Summary
- index common join columns in books/authors and books/series link tables
- add book/value indexes for custom column link tables
- ensure `scripts/init_schema.php` creates the same indexes for fresh databases

## Testing
- `php -l scripts/init_schema.php`
- `sqlite3 :memory: ...` (EXPLAIN QUERY PLAN shows use of idx_books_authors_link_author)
- `sqlite3 :memory: ...` (EXPLAIN QUERY PLAN shows use of idx_books_series_link_series)


------
https://chatgpt.com/codex/tasks/task_e_68934356ae388329961f6891b6bc7bb9