### PR TITLE
Show loading spinner during infinite scroll

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -93,6 +93,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const openLibraryModalEl = document.getElementById('openLibraryModal');
   const openLibraryModal = new bootstrap.Modal(openLibraryModalEl);
 
+  const loadingSpinner = document.getElementById('loadingSpinner');
+  let activeLoads = 0;
+  function showSpinner() {
+    if (loadingSpinner && activeLoads++ === 0) {
+      loadingSpinner.classList.remove('d-none');
+    }
+  }
+  function hideSpinner() {
+    if (loadingSpinner && --activeLoads <= 0) {
+      activeLoads = 0;
+      loadingSpinner.classList.add('d-none');
+    }
+  }
+
   initCoverDimensions(contentArea);
 
   let lowestPage = parseInt(bodyData.page, 10);
@@ -133,6 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadNext() {
     if (highestPage >= totalPages) return;
+    showSpinner();
     try {
       const p = highestPage + 1;
       const els = nextCache.get(p) || await fetchPage(p);
@@ -145,11 +160,14 @@ document.addEventListener('DOMContentLoaded', () => {
       trimPages();
     } catch (err) {
       console.error(err);
+    } finally {
+      hideSpinner();
     }
   }
 
   async function loadPrevious() {
     if (lowestPage <= 1) return;
+    showSpinner();
     try {
       const p = lowestPage - 1;
       const els = prevCache.get(p) || await fetchPage(p);
@@ -164,6 +182,8 @@ document.addEventListener('DOMContentLoaded', () => {
       trimPages();
     } catch (err) {
       console.error(err);
+    } finally {
+      hideSpinner();
     }
   }
 

--- a/list_books.php
+++ b/list_books.php
@@ -770,6 +770,12 @@ body {
     </div>
     <a href="#" id="backToTop" class="btn btn-primary position-fixed end-0 m-3 d-none"><i class="fa-solid fa-arrow-up"></i></a>
 
+    <div id="loadingSpinner" class="position-fixed top-0 start-0 w-100 h-100 d-flex justify-content-center align-items-center bg-white bg-opacity-75 d-none" style="z-index:1050;">
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
     <script src="js/list_books.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- show centered overlay spinner in `list_books.php`
- manage spinner visibility in infinite scroll logic

## Testing
- `php -l list_books.php`
- `node --check js/list_books.js`

------
https://chatgpt.com/codex/tasks/task_e_689348f6c13c8329b64df1c7e45b1ef5