### PR TITLE
Fix stale counts after book deletion

### DIFF
--- a/delete_book.php
+++ b/delete_book.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $bookId = isset($_POST['book_id']) ? (int)$_POST['book_id'] : 0;
@@ -30,6 +31,10 @@ try {
     }
 
     $pdo->commit();
+    invalidateCache('total_books');
+    invalidateCache('shelves');
+    invalidateCache('statuses');
+    invalidateCache('genres');
     echo json_encode(['status' => 'ok']);
 } catch (PDOException $e) {
     $pdo->rollBack();


### PR DESCRIPTION
## Summary
- Clear all book-related caches when a book is removed
- Load cache utilities in delete_book.php so counts stay accurate

## Testing
- `php -l delete_book.php`
- `php -l cache.php`


------
https://chatgpt.com/codex/tasks/task_e_68935f79d0788329bcad1d2efbf312b8