### PR TITLE
Delete book status link before record removal

### DIFF
--- a/delete_book.php
+++ b/delete_book.php
@@ -18,6 +18,11 @@ try {
     $stmt->execute([':id' => $bookId]);
     $authorIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
+    $statusId = ensureMultiValueColumn($pdo, '#status', 'Status');
+    $linkTable = "books_custom_column_{$statusId}_link";
+    $delStatus = $pdo->prepare("DELETE FROM $linkTable WHERE book = :id");
+    $delStatus->execute([':id' => $bookId]);
+
     $delBook = $pdo->prepare('DELETE FROM books WHERE id = :id');
     $delBook->execute([':id' => $bookId]);
 


### PR DESCRIPTION
## Summary
- Ensure `delete_book.php` removes book entries from the status link table
- Clean up status links before deleting the book record

## Testing
- `php -l delete_book.php`


------
https://chatgpt.com/codex/tasks/task_e_68936d229d5483299e0cd82913ce2d0b