### PR TITLE
Add cascading foreign keys for custom columns

### DIFF
--- a/scripts/init_schema.php
+++ b/scripts/init_schema.php
@@ -10,12 +10,9 @@ try {
     $pdo->exec('CREATE INDEX IF NOT EXISTS idx_books_authors_link_author ON books_authors_link(author)');
     $pdo->exec('CREATE INDEX IF NOT EXISTS idx_books_series_link_book ON books_series_link(book)');
     $pdo->exec('CREATE INDEX IF NOT EXISTS idx_books_series_link_series ON books_series_link(series)');
-
-    $stmt = $pdo->query('SELECT id FROM custom_columns');
-    while (($id = $stmt->fetchColumn()) !== false) {
-        $link = "books_custom_column_{$id}_link";
-        $pdo->exec("CREATE INDEX IF NOT EXISTS idx_{$link}_book ON {$link}(book)");
-        $pdo->exec("CREATE INDEX IF NOT EXISTS idx_{$link}_value ON {$link}(value)");
+    $stmt = $pdo->query('SELECT id, is_multiple FROM custom_columns');
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        createCalibreColumnTables($pdo, (int)$row['id'], (bool)$row['is_multiple']);
     }
 } catch (PDOException $e) {
     error_log('Index creation failed: ' . $e->getMessage());


### PR DESCRIPTION
## Summary
- ensure custom column link tables include cascading foreign keys and rebuild old tables if missing
- rebuild all custom column link tables during schema initialization

## Testing
- `php -l db.php`
- `php -l scripts/init_schema.php`
- `php -r 'require "db.php"; $pdo=new PDO("sqlite::memory:"); $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION); $pdo->exec("PRAGMA foreign_keys = ON"); $pdo->exec("CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT);"); $pdo->exec("CREATE TABLE custom_column_1 (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT, link TEXT);"); $pdo->exec("CREATE TABLE books_custom_column_1_link (id INTEGER PRIMARY KEY AUTOINCREMENT, book INTEGER NOT NULL, value INTEGER NOT NULL, UNIQUE(book,value));"); createCalibreColumnTables($pdo, 1, true); print_r($pdo->query("PRAGMA foreign_key_list(books_custom_column_1_link)")->fetchAll(PDO::FETCH_ASSOC));'`


------
https://chatgpt.com/codex/tasks/task_e_68936fb9e24483299e0964905d94e3f6