### PR TITLE
Clean up custom column links when deleting books

### DIFF
--- a/delete_book.php
+++ b/delete_book.php
@@ -18,10 +18,12 @@ try {
     $stmt->execute([':id' => $bookId]);
     $authorIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
-    $statusId = ensureMultiValueColumn($pdo, '#status', 'Status');
-    $linkTable = "books_custom_column_{$statusId}_link";
-    $delStatus = $pdo->prepare("DELETE FROM $linkTable WHERE book = :id");
-    $delStatus->execute([':id' => $bookId]);
+    $tablesStmt = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name GLOB 'books_custom_column_*_link'");
+    $linkTables = $tablesStmt ? $tablesStmt->fetchAll(PDO::FETCH_COLUMN) : [];
+    foreach ($linkTables as $table) {
+        $stmtDel = $pdo->prepare("DELETE FROM $table WHERE book = :id");
+        $stmtDel->execute([':id' => $bookId]);
+    }
 
     $delBook = $pdo->prepare('DELETE FROM books WHERE id = :id');
     $delBook->execute([':id' => $bookId]);


### PR DESCRIPTION
## Summary
- remove status-specific logic and dynamically delete a book's entries from all custom column link tables

## Testing
- `php -l delete_book.php`


------
https://chatgpt.com/codex/tasks/task_e_68937b01c66083299355dd056da3c447