### PR TITLE
Add cleanup script for orphaned custom column entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Run the schema initialization script once for each Calibre library:
 php scripts/init_schema.php
 ```
 
+If upgrading from a previous version that left orphaned entries in
+`books_custom_column_*` tables, run the cleanup script once to remove
+those dangling rows:
+
+```
+php scripts/fix_orphaned_custom_columns.php
+```
+
 Each book also has a "Shelf" value stored in the custom column labeled `#shelf`. Available shelf names are kept in a `shelves` table and displayed in the sidebar. You can add or remove shelves from that sidebar and click a shelf name to filter the list. Each book row includes a drop-down to select one of the shelves. All books default to `Ebook Calibre` if no explicit value is set.
 
 Books can now store freeform notes in the single-value custom column labeled `#notes`.

--- a/scripts/fix_orphaned_custom_columns.php
+++ b/scripts/fix_orphaned_custom_columns.php
@@ -1,0 +1,72 @@
+<?php
+// One-time cleanup script to remove orphaned entries from Calibre
+// book custom column tables. Orphaned rows can appear if books or
+// custom column values were deleted without cleaning up their links.
+//
+// Run this script once as an admin to tidy existing databases:
+//   php scripts/fix_orphaned_custom_columns.php
+//
+// The script connects to the configured database and scans all tables
+// named books_custom_column_*. For each table it removes rows whose
+// book id no longer exists in the books table or whose value id no
+// longer exists in the corresponding custom_column_X table.
+
+require_once __DIR__ . '/../db.php';
+
+$pdo = getDatabaseConnection();
+
+$totalRemoved = 0;
+
+try {
+    // Fetch all book custom column tables
+    $stmt = $pdo->query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'books_custom_column_%'"
+    );
+    $tables = $stmt ? $stmt->fetchAll(PDO::FETCH_COLUMN) : [];
+
+    foreach ($tables as $table) {
+        if (!preg_match('/books_custom_column_(\d+)(?:_link)?$/', $table, $m)) {
+            continue;
+        }
+        $id = (int)$m[1];
+        $valueTable = "custom_column_{$id}";
+
+        // Ensure the value table exists before proceeding
+        $exists = $pdo->prepare(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?"
+        );
+        $exists->execute([$valueTable]);
+        if (!$exists->fetchColumn()) {
+            continue; // Skip if the value table is missing
+        }
+
+        // Remove link rows referencing missing books
+        $removedBooks = $pdo->exec(
+            "DELETE FROM {$table} WHERE book NOT IN (SELECT id FROM books)"
+        );
+        if ($removedBooks === false) {
+            $removedBooks = 0;
+        }
+
+        // Remove link rows referencing missing values
+        $removedValues = $pdo->exec(
+            "DELETE FROM {$table} WHERE value NOT IN (SELECT id FROM {$valueTable})"
+        );
+        if ($removedValues === false) {
+            $removedValues = 0;
+        }
+
+        $totalRemoved += $removedBooks + $removedValues;
+        echo sprintf(
+            "%s: removed %d book orphans, %d value orphans\n",
+            $table,
+            $removedBooks,
+            $removedValues
+        );
+    }
+
+    echo "Total orphaned rows removed: {$totalRemoved}\n";
+} catch (PDOException $e) {
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add `fix_orphaned_custom_columns.php` script to remove stale rows from `books_custom_column_*` tables
- document cleanup step in README for upgrading databases

## Testing
- `php -l scripts/fix_orphaned_custom_columns.php`
- `php scripts/fix_orphaned_custom_columns.php` *(fails: no such table: custom_columns)*

------
https://chatgpt.com/codex/tasks/task_e_68937dd36bd483298c733a1cd2b1c3d6