### PR TITLE
Clarify per-user preferences storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ rename or delete genres from that list just like shelves and status values.
 ## Preferences
 
 Visit `login.php` to sign in. User accounts and their preferences are stored in
-`users.json`. After logging in you can open `preferences.php` to set the path to
-your Calibre `metadata.db` file. Preferences are saved per user without using
-PHP sessions. You can still choose to save the path globally for all users which
-updates the `preferences.json` file.
+`users.json`, including the database path for each user. After logging in you
+can open `preferences.php` to set the path to your Calibre `metadata.db` file.
+Preferences are saved per user without using PHP sessions.
 
 ## Adding Your Own Books
 


### PR DESCRIPTION
## Summary
- Clarify that each user's database path is stored in `users.json`
- Remove outdated reference to `preferences.json`

## Testing
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_e_6893817a28d08329a79d83ca3694ca5d