### PR TITLE
Add manual cache refresh option

### DIFF
--- a/cache.php
+++ b/cache.php
@@ -48,6 +48,25 @@ function invalidateCache(string $key): void {
     }
 }
 
+/**
+ * Clear all cached files for the current user.
+ */
+function clearUserCache(): void {
+    $user = currentUser();
+    if (!$user) {
+        return;
+    }
+    $dir = CACHE_DIR . '/' . $user;
+    if (!is_dir($dir)) {
+        return;
+    }
+    foreach (glob($dir . '/*.json') ?: [] as $file) {
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+}
+
 // Domain-specific helpers --------------------------------------------------
 
 /** Fetch shelves with book counts, cached. */

--- a/preferences.php
+++ b/preferences.php
@@ -1,56 +1,62 @@
 <?php
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $message = '';
 $alertClass = 'success';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $dbPath = trim($_POST['db_path'] ?? '');
-    $libPath = trim($_POST['library_path'] ?? '');
-    $remoteDir = trim($_POST['REMOTE_DIR'] ?? '');
-    $device = trim($_POST['DEVICE'] ?? '');
-
-    if ($dbPath !== '') {
-        setUserPreference(currentUser(), 'db_path', $dbPath);
-        if (isset($_POST['save_global'])) {
-            setPreference('db_path', $dbPath);
-        }
-    }
-
-    if ($libPath !== '') {
-        setUserPreference(currentUser(), 'library_path', $libPath);
-        if (isset($_POST['save_global'])) {
-            setPreference('library_path', $libPath);
-        }
-    }
-
-    if ($remoteDir !== '') {
-        setUserPreference(currentUser(), 'REMOTE_DIR', $remoteDir);
-        if (isset($_POST['save_global'])) {
-            setPreference('REMOTE_DIR', $remoteDir);
-        }
-    }
-
-    if ($device !== '') {
-        setUserPreference(currentUser(), 'DEVICE', $device);
-        if (isset($_POST['save_global'])) {
-            setPreference('DEVICE', $device);
-        }
-    }
-
-    $dbWritable = $dbPath === '' ? true : (file_exists($dbPath)
-        ? is_writable($dbPath)
-        : (is_dir(dirname($dbPath)) && is_writable(dirname($dbPath))));
-    $libWritable = $libPath === '' ? true : (is_dir($libPath) && is_writable($libPath));
-
-    if ($dbWritable && $libWritable) {
-        $message = 'Preferences saved.';
+    if (isset($_POST['clear_cache'])) {
+        clearUserCache();
+        $message = 'Cache cleared.';
     } else {
-        $alertClass = 'danger';
-        if (!$dbWritable) {
-            $message = 'Database path is not writable.';
-        } elseif (!$libWritable) {
-            $message = 'Library path is not writable.';
+        $dbPath = trim($_POST['db_path'] ?? '');
+        $libPath = trim($_POST['library_path'] ?? '');
+        $remoteDir = trim($_POST['REMOTE_DIR'] ?? '');
+        $device = trim($_POST['DEVICE'] ?? '');
+
+        if ($dbPath !== '') {
+            setUserPreference(currentUser(), 'db_path', $dbPath);
+            if (isset($_POST['save_global'])) {
+                setPreference('db_path', $dbPath);
+            }
+        }
+
+        if ($libPath !== '') {
+            setUserPreference(currentUser(), 'library_path', $libPath);
+            if (isset($_POST['save_global'])) {
+                setPreference('library_path', $libPath);
+            }
+        }
+
+        if ($remoteDir !== '') {
+            setUserPreference(currentUser(), 'REMOTE_DIR', $remoteDir);
+            if (isset($_POST['save_global'])) {
+                setPreference('REMOTE_DIR', $remoteDir);
+            }
+        }
+
+        if ($device !== '') {
+            setUserPreference(currentUser(), 'DEVICE', $device);
+            if (isset($_POST['save_global'])) {
+                setPreference('DEVICE', $device);
+            }
+        }
+
+        $dbWritable = $dbPath === '' ? true : (file_exists($dbPath)
+            ? is_writable($dbPath)
+            : (is_dir(dirname($dbPath)) && is_writable(dirname($dbPath))));
+        $libWritable = $libPath === '' ? true : (is_dir($libPath) && is_writable($libPath));
+
+        if ($dbWritable && $libWritable) {
+            $message = 'Preferences saved.';
+        } else {
+            $alertClass = 'danger';
+            if (!$dbWritable) {
+                $message = 'Database path is not writable.';
+            } elseif (!$libWritable) {
+                $message = 'Library path is not writable.';
+            }
         }
     }
 }
@@ -102,6 +108,7 @@ $currentDevice = getUserPreference(currentUser(), 'DEVICE', getPreference('DEVIC
       </label>
     </div>
     <button type="submit" class="btn btn-primary">Save</button>
+    <button type="submit" name="clear_cache" value="1" class="btn btn-warning ms-2">Clear Cache</button>
     <a href="fix_author_sort.php" class="btn btn-secondary ms-2">Fix Author Sort</a>
   </form>
 </body>


### PR DESCRIPTION
## Summary
- allow users to clear their JSON cache from preferences
- implement `clearUserCache()` helper to remove per-user cache files

## Testing
- `php -l cache.php preferences.php`


------
https://chatgpt.com/codex/tasks/task_e_6893935db33883299b6904e5a4f43336