### PR TITLE
Replace shelf dropdown with status filter in navbar

### DIFF
--- a/navbar.php
+++ b/navbar.php
@@ -113,8 +113,8 @@ $statusNameVal = isset($statusName) ? $statusName : '';
           </a>
         </li>
 
-        <!-- Shelf Selector -->
-        <?php if (isset($shelfList) && function_exists('buildBaseUrl')): ?>
+        <!-- Status Selector -->
+        <?php if (isset($statusOptions) && function_exists('buildBaseUrl')): ?>
         <li class="nav-item">
           <form class="d-flex" method="get" action="<?= htmlspecialchars($action) ?>">
             <input type="hidden" name="page" value="1">
@@ -122,15 +122,15 @@ $statusNameVal = isset($statusName) ? $statusName : '';
             <?php if ($authorIdVal): ?><input type="hidden" name="author_id" value="<?= htmlspecialchars($authorIdVal) ?>"><?php endif; ?>
             <?php if ($seriesIdVal): ?><input type="hidden" name="series_id" value="<?= htmlspecialchars($seriesIdVal) ?>"><?php endif; ?>
             <?php if ($genreIdVal): ?><input type="hidden" name="genre_id" value="<?= htmlspecialchars($genreIdVal) ?>"><?php endif; ?>
-            <?php if ($statusNameVal !== ''): ?><input type="hidden" name="status" value="<?= htmlspecialchars($statusNameVal) ?>"><?php endif; ?>
+            <?php if ($shelfNameVal !== ''): ?><input type="hidden" name="shelf" value="<?= htmlspecialchars($shelfNameVal) ?>"><?php endif; ?>
             <?php if ($sortVal !== ''): ?><input type="hidden" name="sort" value="<?= htmlspecialchars($sortVal) ?>"><?php endif; ?>
 
             <div class="input-group">
-              <span class="input-group-text"><i class="fa-solid fa-layer-group"></i></span>
-              <select class="form-select" name="shelf" id="shelfSelect">
-                <option value=""<?= $shelfNameVal === '' ? ' selected' : '' ?>>All Shelves</option>
-                <?php foreach ($shelfList as $s): ?>
-                  <option value="<?= htmlspecialchars($s) ?>"<?= $shelfNameVal === $s ? ' selected' : '' ?>><?= htmlspecialchars($s) ?></option>
+              <span class="input-group-text"><i class="fa-solid fa-list-check"></i></span>
+              <select class="form-select" name="status" id="statusSelect">
+                <option value=""<?= $statusNameVal === '' ? ' selected' : '' ?>>All Status</option>
+                <?php foreach ($statusOptions as $s): ?>
+                  <option value="<?= htmlspecialchars($s) ?>"<?= $statusNameVal === $s ? ' selected' : '' ?>><?= htmlspecialchars($s) ?></option>
                 <?php endforeach; ?>
               </select>
             </div>


### PR DESCRIPTION
## Summary
- Replace shelves dropdown with status dropdown in navbar
- Keep query context fields so searches and sorts persist existing filters

## Testing
- `php -l navbar.php`

------
https://chatgpt.com/codex/tasks/task_e_68939dee37248329919481d97ba3e109