### PR TITLE
Preserve pagination and position when returning from book view

### DIFF
--- a/book.php
+++ b/book.php
@@ -33,6 +33,20 @@ $commentStmt->execute([$id]);
 $description = $commentStmt->fetchColumn() ?: '';
 $notes = '';
 
+$returnPage = isset($_GET['page']) ? max(1, (int)$_GET['page']) : null;
+$returnItem = isset($_GET['item']) ? preg_replace('/[^A-Za-z0-9_-]/', '', $_GET['item']) : '';
+$backToListUrl = 'list_books.php';
+$backParams = [];
+if ($returnPage) {
+    $backParams['page'] = $returnPage;
+}
+if ($backParams) {
+    $backToListUrl .= '?' . http_build_query($backParams);
+}
+if ($returnItem !== '') {
+    $backToListUrl .= '#' . $returnItem;
+}
+
 $updated = false;
 $sendMessage = null;
 $sendRequested = ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['send_to_device']));
@@ -434,7 +448,7 @@ if ($sendRequested) {
 <body class="pt-5" data-book-id="<?= (int)$book['id'] ?>" data-search-query="<?= htmlspecialchars($book['title'] . ' ' . $book['authors'], ENT_QUOTES) ?>"<?php if($ebookFileRel): ?> data-ebook-file="<?= htmlspecialchars($ebookFileRel) ?>"<?php endif; ?><?php if(!empty($book['isbn'])): ?> data-isbn="<?= htmlspecialchars($book['isbn']) ?>"<?php endif; ?>>
 <?php include "navbar_other.php"; ?>
 <div class="container my-4">
-    <a href="list_books.php" class="btn btn-secondary mb-3">
+    <a href="<?= htmlspecialchars($backToListUrl) ?>" class="btn btn-secondary mb-3">
         <i class="fa-solid fa-arrow-left me-1"></i> Back to list
     </a>
     <a href="list_books.php?search=<?= urlencode($book['title']) ?>&source=local" class="btn btn-secondary mb-3 ms-2">
@@ -696,7 +710,7 @@ if ($sendRequested) {
                         <!-- Form Actions -->
                         <div class="d-flex justify-content-between mt-4">
                             <div>
-                                <a href="list_books.php" class="btn btn-secondary">
+                                <a href="<?= htmlspecialchars($backToListUrl) ?>" class="btn btn-secondary">
                                     <i class="fa-solid fa-arrow-left me-1"></i> Back to list
                                 </a>
                                 <a href="list_books.php?search=<?= urlencode($book['title']) ?>&source=local" class="btn btn-secondary ms-2">

--- a/list_books.php
+++ b/list_books.php
@@ -341,6 +341,7 @@ $rowTemplateData = [
     'statusOptions' => $statusOptions,
     'genreList' => $genreList,
     'sort' => $sort,
+    'page' => $page,
 ];
 
 if ($isAjax) {

--- a/templates/book_row.php
+++ b/templates/book_row.php
@@ -2,7 +2,7 @@
             <!-- Left: Thumbnail -->
             <div class="col-md-2 col-12 text-center cover-wrapper">
                 <?php if (!empty($book['has_cover'])): ?>
-                    <a href="book.php?id=<?= urlencode($book['id']) ?>">
+                    <a href="book.php?id=<?= urlencode($book['id']) ?>&page=<?= urlencode($page) ?>&item=<?= urlencode('item-' . $index) ?>">
                         <div class="position-relative d-inline-block">
                             <img id="coverImage<?= (int)$book['id'] ?>" src="<?= htmlspecialchars(getLibraryPath() . '/' . $book['path'] . '/cover.jpg') ?>"
                                  alt="Cover"
@@ -25,7 +25,7 @@
                         <i class="fa-solid fa-circle-exclamation text-danger me-1" title="File missing"></i>
                     <?php endif; ?>
                      
-                    <a href="book.php?id=<?= urlencode($book['id']) ?>" class="fw-bold book-title me-1"
+                    <a href="book.php?id=<?= urlencode($book['id']) ?>&page=<?= urlencode($page) ?>&item=<?= urlencode('item-' . $index) ?>" class="fw-bold book-title me-1"
                        data-book-id="<?= htmlspecialchars($book['id']) ?>">
                          <?= htmlspecialchars($book['title']) ?>
                     </a>


### PR DESCRIPTION
## Summary
- Keep track of list pagination when navigating to a book and embed the book row's div id in the link.
- Use that information in `book.php` to build a "Back to list" URL that returns to the same page and item anchor.

## Testing
- `php -l list_books.php`
- `php -l templates/book_row.php`
- `php -l book.php`


------
https://chatgpt.com/codex/tasks/task_e_6893cf0f803c8329b6264c95c09549fc