### PR TITLE
Handle custom subseries index in book list

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -46,7 +46,7 @@ try {
         $subseriesLinkTable  = "books_custom_column_{$subseriesColumnId}_link";
         $cols = $pdo->query("PRAGMA table_info($subseriesLinkTable)")->fetchAll(PDO::FETCH_ASSOC);
         foreach ($cols as $col) {
-            if (in_array($col['name'], ['book_index','sort'], true)) {
+            if (in_array($col['name'], ['book_index', 'sort', 'extra'], true)) {
                 $subseriesIndexColumn = $col['name'];
                 break;
             }


### PR DESCRIPTION
## Summary
- Support `extra` as a valid subseries index column when inspecting subseries link tables

## Testing
- `php -l list_books.php`
- Executed `list_books.php` against sample database and saw "Subseries One (2)" in output

------
https://chatgpt.com/codex/tasks/task_e_6893d7dffac08329b41baa6cfb9461e8