### PR TITLE
Add modal to extract and save book covers

### DIFF
--- a/book.php
+++ b/book.php
@@ -512,7 +512,7 @@ if ($sendRequested) {
     <?php endif; ?>
 
     <!-- Two-column layout -->
-    <div class="row">
+        <div class="row">
         <!-- Left Column: Book Metadata -->
         <div class="col-lg-4 mb-4">
             <?php if (!empty($book['has_cover'])): ?>
@@ -524,6 +524,10 @@ if ($sendRequested) {
                 </div>
             <?php else: ?>
                 <div class="text-muted">No cover</div>
+            <?php endif; ?>
+
+            <?php if ($ebookFileRel): ?>
+                <button type="button" id="extractCoverBtn" class="btn btn-secondary mb-4">Extract Cover</button>
             <?php endif; ?>
 
             <div class="border p-3 rounded bg-light shadow-sm">
@@ -737,6 +741,7 @@ if ($sendRequested) {
 
 
     <?php include 'metadata_modal.php'; ?>
+    <?php include 'cover_modal.php'; ?>
   </div>
     
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>

--- a/cover_modal.php
+++ b/cover_modal.php
@@ -1,0 +1,18 @@
+<div class="modal fade" id="coverModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Extracted Cover</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <img id="extractedCoverImg" src="" alt="Cover" class="img-fluid mb-3">
+        <div id="extractedCoverSize" class="text-muted"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="useExtractedCover">Use This</button>
+      </div>
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
## Summary
- Add **Extract Cover** button on book detail page to retrieve cover images from the ebook file via `ebook-meta`.
- Introduce a Bootstrap modal to preview the extracted cover and its dimensions, with an option to save it.
- Extend metadata update endpoint to handle base64 cover data and persist the cover.

## Testing
- `php -l book.php`
- `php -l update_metadata.php`
- `php -l cover_modal.php`
- `node --check js/book.js`


------
https://chatgpt.com/codex/tasks/task_e_6893e4166ab08329bbf8203cf25ff209