### PR TITLE
Add author management actions

### DIFF
--- a/authors.php
+++ b/authors.php
@@ -1,9 +1,11 @@
 <?php
 require_once 'db.php';
+require_once 'cache.php';
 requireLogin();
 
 $pdo = getDatabaseConnection();
 $authors = $pdo->query('SELECT id, name FROM authors ORDER BY sort')->fetchAll(PDO::FETCH_ASSOC);
+$statuses = getCachedStatuses($pdo);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -24,15 +26,25 @@ $authors = $pdo->query('SELECT id, name FROM authors ORDER BY sort')->fetchAll(P
     <?php else: ?>
         <ul class="list-group">
             <?php foreach ($authors as $a): ?>
-                <li class="list-group-item">
-                    <a href="list_books.php?author_id=<?= (int)$a['id'] ?>">
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <a href="list_books.php?author_id=<?= (int)$a['id'] ?>" class="flex-grow-1">
                         <?= htmlspecialchars($a['name']) ?>
                     </a>
+                    <select class="form-select form-select-sm ms-2 author-status" data-author-id="<?= (int)$a['id'] ?>" style="width: auto;">
+                        <option value="">Set status...</option>
+                        <?php foreach ($statuses as $s): ?>
+                            <option value="<?= htmlspecialchars($s['value']) ?>"><?= htmlspecialchars($s['value']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <button type="button" class="btn btn-sm btn-danger ms-2 delete-author" data-author-id="<?= (int)$a['id'] ?>">
+                        <i class="fa-solid fa-trash"></i>
+                    </button>
                 </li>
             <?php endforeach; ?>
         </ul>
     <?php endif; ?>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script src="js/authors.js"></script>
 </body>
 </html>

--- a/delete_author.php
+++ b/delete_author.php
@@ -1,0 +1,61 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+require_once 'cache.php';
+requireLogin();
+
+$authorId = isset($_POST['author_id']) ? (int)$_POST['author_id'] : 0;
+if ($authorId <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid author id']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $pdo->beginTransaction();
+
+    $booksStmt = $pdo->prepare('SELECT book FROM books_authors_link WHERE author = :id');
+    $booksStmt->execute([':id' => $authorId]);
+    $bookIds = $booksStmt->fetchAll(PDO::FETCH_COLUMN);
+
+    $authorIds = [$authorId];
+    if ($bookIds) {
+        $placeholders = implode(',', array_fill(0, count($bookIds), '?'));
+        $aStmt = $pdo->prepare("SELECT DISTINCT author FROM books_authors_link WHERE book IN ($placeholders)");
+        $aStmt->execute($bookIds);
+        $authorIds = $aStmt->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    $tablesStmt = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name GLOB 'books_custom_column_*_link'");
+    $linkTables = $tablesStmt ? $tablesStmt->fetchAll(PDO::FETCH_COLUMN) : [];
+    $delBook = $pdo->prepare('DELETE FROM books WHERE id = :id');
+
+    foreach ($bookIds as $bookId) {
+        foreach ($linkTables as $table) {
+            $pdo->prepare("DELETE FROM $table WHERE book = :id")->execute([':id' => $bookId]);
+        }
+        $delBook->execute([':id' => $bookId]);
+    }
+
+    $check = $pdo->prepare('SELECT COUNT(*) FROM books_authors_link WHERE author = ?');
+    $delAuthor = $pdo->prepare('DELETE FROM authors WHERE id = ?');
+    foreach ($authorIds as $aid) {
+        $check->execute([$aid]);
+        if ((int)$check->fetchColumn() === 0) {
+            $delAuthor->execute([$aid]);
+        }
+    }
+
+    $pdo->commit();
+    invalidateCache('total_books');
+    invalidateCache('shelves');
+    invalidateCache('statuses');
+    invalidateCache('genres');
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/js/authors.js
+++ b/js/authors.js
@@ -1,0 +1,33 @@
+// Handle status changes and author deletions on authors page
+
+document.addEventListener('change', async e => {
+  if (e.target.classList.contains('author-status')) {
+    const authorId = e.target.dataset.authorId;
+    const value = e.target.value;
+    await fetch('update_author_status.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ author_id: authorId, value })
+    });
+  }
+});
+
+document.addEventListener('click', async e => {
+  const btn = e.target.closest('.delete-author');
+  if (!btn) return;
+  if (!confirm('Delete this author and all associated books?')) return;
+  const authorId = btn.dataset.authorId;
+  try {
+    const res = await fetch('delete_author.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ author_id: authorId })
+    });
+    const data = await res.json();
+    if (data.status === 'ok') {
+      btn.closest('li').remove();
+    }
+  } catch (err) {
+    console.error(err);
+  }
+});

--- a/update_author_status.php
+++ b/update_author_status.php
@@ -1,0 +1,69 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+requireLogin();
+
+$authorId = isset($_POST['author_id']) ? (int)$_POST['author_id'] : 0;
+$value = trim($_POST['value'] ?? '');
+
+if ($authorId <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid input']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+try {
+    $pdo->beginTransaction();
+    $pdo->exec("CREATE TABLE IF NOT EXISTS reading_log (book INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE, year INTEGER, read_date TEXT)");
+    $cols = $pdo->query("PRAGMA table_info(reading_log)")->fetchAll(PDO::FETCH_COLUMN, 1);
+    if (!in_array('read_date', $cols, true)) {
+        $pdo->exec("ALTER TABLE reading_log ADD COLUMN read_date TEXT");
+    }
+
+    $statusId = ensureMultiValueColumn($pdo, '#status', 'Status');
+    $valueTable = "custom_column_{$statusId}";
+    $linkTable = "books_custom_column_{$statusId}_link";
+
+    $stmt = $pdo->prepare('SELECT book FROM books_authors_link WHERE author = :author');
+    $stmt->execute([':author' => $authorId]);
+    $bookIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+    if ($bookIds) {
+        $delStmt = $pdo->prepare("DELETE FROM $linkTable WHERE book = :book");
+        foreach ($bookIds as $bookId) {
+            $delStmt->execute([':book' => $bookId]);
+        }
+
+        if ($value !== '') {
+            $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+                ->execute([':val' => $value]);
+            $valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+            $valStmt->execute([':val' => $value]);
+            $valId = $valStmt->fetchColumn();
+            $insStmt = $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :val)");
+            foreach ($bookIds as $bookId) {
+                $insStmt->execute([':book' => $bookId, ':val' => $valId]);
+            }
+        }
+
+        $currentYear = (int)date('Y');
+        $rlInsert = $pdo->prepare('REPLACE INTO reading_log (book, year, read_date) VALUES (:book, :year, :read_date)');
+        $rlDelete = $pdo->prepare('DELETE FROM reading_log WHERE book = :book');
+        foreach ($bookIds as $bookId) {
+            if (strcasecmp($value, 'Read Challenge') === 0) {
+                $rlInsert->execute([':book' => $bookId, ':year' => $currentYear, ':read_date' => date('Y-m-d')]);
+            } else {
+                $rlDelete->execute([':book' => $bookId]);
+            }
+        }
+    }
+
+    $pdo->commit();
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- Allow setting a reading status for all books by an author directly from the Authors page
- Enable deleting an author along with their books and related link-table entries
- Add client-side logic to drive author status updates and deletions

## Testing
- `php -l authors.php update_author_status.php delete_author.php`


------
https://chatgpt.com/codex/tasks/task_e_6894b4a1d9c4832999f2681840767b4f