### PR TITLE
Add genre management and series info to authors page

### DIFF
--- a/authors.php
+++ b/authors.php
@@ -4,8 +4,18 @@ require_once 'cache.php';
 requireLogin();
 
 $pdo = getDatabaseConnection();
-$authors = $pdo->query('SELECT id, name FROM authors ORDER BY sort')->fetchAll(PDO::FETCH_ASSOC);
+$authors = $pdo->query(
+    "SELECT a.id, a.name, COUNT(DISTINCT bal.book) AS book_count,\n" .
+    "       GROUP_CONCAT(DISTINCT s.id || ':' || s.name, '|') AS series_list\n" .
+    "FROM authors a\n" .
+    "LEFT JOIN books_authors_link bal ON a.id = bal.author\n" .
+    "LEFT JOIN books_series_link bsl ON bal.book = bsl.book\n" .
+    "LEFT JOIN series s ON s.id = bsl.series\n" .
+    "GROUP BY a.id, a.name\n" .
+    "ORDER BY a.sort"
+)->fetchAll(PDO::FETCH_ASSOC);
 $statuses = getCachedStatuses($pdo);
+$genres = getCachedGenres($pdo);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -26,10 +36,30 @@ $statuses = getCachedStatuses($pdo);
     <?php else: ?>
         <ul class="list-group">
             <?php foreach ($authors as $a): ?>
+                <?php $seriesList = $a['series_list'] !== null && $a['series_list'] !== '' ? explode('|', $a['series_list']) : []; ?>
                 <li class="list-group-item d-flex justify-content-between align-items-center">
-                    <a href="list_books.php?author_id=<?= (int)$a['id'] ?>" class="flex-grow-1">
-                        <?= htmlspecialchars($a['name']) ?>
-                    </a>
+                    <div class="flex-grow-1">
+                        <a href="list_books.php?author_id=<?= (int)$a['id'] ?>">
+                            <?= htmlspecialchars($a['name']) ?>
+                        </a>
+                        <div class="small text-muted">
+                            <?= (int)$a['book_count'] ?> book<?= ((int)$a['book_count'] === 1) ? '' : 's' ?>
+                            <?php if (!empty($seriesList)): ?>
+                                — Series:
+                                <?php foreach ($seriesList as $i => $s): ?>
+                                    <?php list($sid, $sname) = explode(':', $s, 2); ?>
+                                    <?php if ($i > 0) echo ', '; ?>
+                                    <a href="list_books.php?series_id=<?= (int)$sid ?>" class="text-reset text-decoration-underline"><?= htmlspecialchars($sname) ?></a>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                    <select class="form-select form-select-sm ms-2 author-genre" data-author-id="<?= (int)$a['id'] ?>" style="width: auto;">
+                        <option value="">Set genre...</option>
+                        <?php foreach ($genres as $g): ?>
+                            <option value="<?= htmlspecialchars($g['value']) ?>"><?= htmlspecialchars($g['value']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
                     <select class="form-select form-select-sm ms-2 author-status" data-author-id="<?= (int)$a['id'] ?>" style="width: auto;">
                         <option value="">Set status...</option>
                         <?php foreach ($statuses as $s): ?>

--- a/js/authors.js
+++ b/js/authors.js
@@ -9,6 +9,14 @@ document.addEventListener('change', async e => {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({ author_id: authorId, value })
     });
+  } else if (e.target.classList.contains('author-genre')) {
+    const authorId = e.target.dataset.authorId;
+    const value = e.target.value;
+    await fetch('update_author_genre.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ author_id: authorId, value })
+    });
   }
 });
 

--- a/update_author_genre.php
+++ b/update_author_genre.php
@@ -1,0 +1,55 @@
+<?php
+header('Content-Type: application/json');
+require_once 'db.php';
+require_once 'cache.php';
+requireLogin();
+
+$authorId = isset($_POST['author_id']) ? (int)$_POST['author_id'] : 0;
+$value = isset($_POST['value']) ? trim((string)$_POST['value']) : '';
+
+if ($authorId <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid input']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+
+try {
+    $pdo->beginTransaction();
+    $genreId = ensureMultiValueColumn($pdo, '#genre', 'Genre');
+    $valueTable = "custom_column_{$genreId}";
+    $linkTable = "books_custom_column_{$genreId}_link";
+
+    $stmt = $pdo->prepare('SELECT book FROM books_authors_link WHERE author = :author');
+    $stmt->execute([':author' => $authorId]);
+    $bookIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+    if ($bookIds) {
+        $delStmt = $pdo->prepare("DELETE FROM $linkTable WHERE book = :book");
+        foreach ($bookIds as $bookId) {
+            $delStmt->execute([':book' => $bookId]);
+        }
+
+        if ($value !== '') {
+            $pdo->prepare("INSERT OR IGNORE INTO $valueTable (value) VALUES (:val)")
+                ->execute([':val' => $value]);
+            $valStmt = $pdo->prepare("SELECT id FROM $valueTable WHERE value = :val");
+            $valStmt->execute([':val' => $value]);
+            $valId = $valStmt->fetchColumn();
+            $insStmt = $pdo->prepare("INSERT INTO $linkTable (book, value) VALUES (:book, :val)");
+            foreach ($bookIds as $bookId) {
+                $insStmt->execute([':book' => $bookId, ':val' => $valId]);
+            }
+        }
+    }
+
+    $pdo->commit();
+    invalidateCache('genres');
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- Add book counts, series links, and genre selection to author list
- Handle author-level genre updates via JS
- Provide backend endpoint to set genre for all books by an author

## Testing
- `php -l authors.php update_author_genre.php`
- `node --check js/authors.js`


------
https://chatgpt.com/codex/tasks/task_e_6894c044aeb88329a43d89dbca22aa32