### PR TITLE
Replace datalist author autocomplete with custom dropdown

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -3,21 +3,74 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestionList = document.getElementById('authorSuggestions');
 
   if (searchInput && suggestionList) {
-    searchInput.addEventListener('input', async () => {
-      const term = searchInput.value.trim();
+    let debounceTimer;
+    let selectedIndex = -1;
+
+    const clearSuggestions = () => {
       suggestionList.innerHTML = '';
-      if (term.length < 2) return;
+      suggestionList.style.display = 'none';
+      selectedIndex = -1;
+    };
+
+    const renderSuggestions = (data) => {
+      clearSuggestions();
+      if (!data.length) return;
+      data.forEach(name => {
+        const li = document.createElement('li');
+        li.textContent = name;
+        li.className = 'list-group-item list-group-item-action';
+        li.addEventListener('mousedown', (e) => {
+          e.preventDefault();
+          searchInput.value = name;
+          clearSuggestions();
+        });
+        suggestionList.appendChild(li);
+      });
+      suggestionList.style.display = 'block';
+    };
+
+    const fetchSuggestions = async () => {
+      const term = searchInput.value.trim();
+      if (term.length < 2) { clearSuggestions(); return; }
       try {
         const res = await fetch(`author_autocomplete.php?term=${encodeURIComponent(term)}`);
         const data = await res.json();
-        suggestionList.innerHTML = '';
-        data.forEach(name => {
-          const opt = document.createElement('option');
-          opt.value = name;
-          suggestionList.appendChild(opt);
-        });
+        renderSuggestions(data);
       } catch (err) {
         console.error(err);
+      }
+    };
+
+    searchInput.addEventListener('input', () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(fetchSuggestions, 300);
+    });
+
+    searchInput.addEventListener('keydown', (e) => {
+      const items = suggestionList.querySelectorAll('li');
+      if (!items.length) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        selectedIndex = (selectedIndex + 1) % items.length;
+        items.forEach((item, idx) => item.classList.toggle('active', idx === selectedIndex));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        selectedIndex = (selectedIndex - 1 + items.length) % items.length;
+        items.forEach((item, idx) => item.classList.toggle('active', idx === selectedIndex));
+      } else if (e.key === 'Enter') {
+        if (selectedIndex >= 0) {
+          e.preventDefault();
+          searchInput.value = items[selectedIndex].textContent;
+          clearSuggestions();
+        }
+      } else if (e.key === 'Escape') {
+        clearSuggestions();
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!suggestionList.contains(e.target) && e.target !== searchInput) {
+        clearSuggestions();
       }
     });
   }

--- a/navbar.php
+++ b/navbar.php
@@ -50,9 +50,9 @@ $statusNameVal = isset($statusName) ? $statusName : '';
           <?php if ($shelfNameVal !== ''): ?><input type="hidden" name="shelf" value="<?= htmlspecialchars($shelfNameVal) ?>"><?php endif; ?>
           <?php if ($statusNameVal !== ''): ?><input type="hidden" name="status" value="<?= htmlspecialchars($statusNameVal) ?>"><?php endif; ?>
 
-          <div class="input-group">
-            <input class="form-control" type="search" name="search" style="width: 20rem;" placeholder="Search books..." value="<?= htmlspecialchars($searchVal) ?>" aria-label="Search" list="authorSuggestions">
-            <datalist id="authorSuggestions"></datalist>
+          <div class="input-group position-relative">
+            <input class="form-control" type="search" name="search" style="width: 20rem;" placeholder="Search books..." value="<?= htmlspecialchars($searchVal) ?>" aria-label="Search" autocomplete="off">
+            <ul id="authorSuggestions" class="list-group position-absolute w-100" style="z-index:1000; display:none; top:100%; left:0;"></ul>
             <select name="source" class="form-select" style="max-width: 12rem;">
               <option value="local"<?= $sourceVal === 'local' ? ' selected' : '' ?>>Local</option>
               <option value="openlibrary"<?= $sourceVal === 'openlibrary' ? ' selected' : '' ?>>Open Library</option>


### PR DESCRIPTION
## Summary
- Replace author `<datalist>` in navbar search with custom list for styling and control
- Implement debounced fetch, keyboard navigation, and click selection for author suggestions

## Testing
- `php -l navbar.php`
- `node --check js/search.js`

------
https://chatgpt.com/codex/tasks/task_e_689520c391fc8329b6ec9c2d4dc1d45d