### PR TITLE
fix: swap series and subseries by name

### DIFF
--- a/js/book.js
+++ b/js/book.js
@@ -590,21 +590,34 @@ document.addEventListener('DOMContentLoaded', () => {
   const swapSeriesSubseriesBtn = document.getElementById('swapSeriesSubseriesBtn');
   if (swapSeriesSubseriesBtn && seriesSelect && subseriesSelect) {
     swapSeriesSubseriesBtn.addEventListener('click', () => {
-      const tmpVal = seriesSelect.value;
-      seriesSelect.value = subseriesSelect.value;
-      subseriesSelect.value = tmpVal;
+      const currentSeriesText = seriesSelect.value === 'new'
+        ? (newSeriesInput ? newSeriesInput.value : '')
+        : seriesSelect.options[seriesSelect.selectedIndex]?.text || '';
+      const currentSubseriesText = subseriesSelect.value === 'new'
+        ? (newSubseriesInput ? newSubseriesInput.value : '')
+        : subseriesSelect.options[subseriesSelect.selectedIndex]?.text || '';
 
-      if (newSeriesInput && newSubseriesInput) {
-        const tmpNew = newSeriesInput.value;
-        newSeriesInput.value = newSubseriesInput.value;
-        newSubseriesInput.value = tmpNew;
-      }
-
+      // swap index numbers
       if (seriesIndexInput && subseriesIndexInput) {
         const tmpIdx = seriesIndexInput.value;
         seriesIndexInput.value = subseriesIndexInput.value;
         subseriesIndexInput.value = tmpIdx;
       }
+
+      // helper to select by text or fallback to 'new'
+      const selectByText = (select, text, newInput) => {
+        const opt = Array.from(select.options).find(o => o.text === text);
+        if (opt) {
+          select.value = opt.value;
+          if (newInput) newInput.value = '';
+        } else {
+          select.value = 'new';
+          if (newInput) newInput.value = text;
+        }
+      };
+
+      selectByText(seriesSelect, currentSubseriesText, newSeriesInput);
+      selectByText(subseriesSelect, currentSeriesText, newSubseriesInput);
 
       toggleSeriesInput();
       toggleSubseriesInput();


### PR DESCRIPTION
## Summary
- swap series and subseries selections using names instead of ids
- keep series/subseries index numbers in sync when swapping

## Testing
- `node --check js/book.js`


------
https://chatgpt.com/codex/tasks/task_e_6895c29119ec83298d0f3638be6163c3