### PR TITLE
Enable clickable subseries filter

### DIFF
--- a/templates/book_row.php
+++ b/templates/book_row.php
@@ -45,7 +45,9 @@
                             <?php endif; ?>
                             <?php if (!empty($book['subseries'])): ?>
                                 &gt;
-                                <?= htmlspecialchars($book['subseries']) ?>
+                                <a href="list_books.php?sort=<?= urlencode($sort) ?>&subseries_id=<?= urlencode($book['subseries_id']) ?>">
+                                    <?= htmlspecialchars($book['subseries']) ?>
+                                </a>
                                 <?php if ($book['subseries_index'] !== null && $book['subseries_index'] !== ''): ?>
                                     (<?= htmlspecialchars($book['subseries_index']) ?>)
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Support `subseries_id` filter in list_books.php with query logic, breadcrumbs and URL generation
- Link displayed subseries names to filtered book list

## Testing
- `php -l list_books.php`
- `php -l templates/book_row.php`


------
https://chatgpt.com/codex/tasks/task_e_6895edcc8b7c8329b14409b00bb3915d