### PR TITLE
Ensure absolute paths for database and library

### DIFF
--- a/add_book_physical.php
+++ b/add_book_physical.php
@@ -25,7 +25,7 @@ if (!file_exists($dbPath)) {
 }
 
 // --- Database Setup ---
-$pdo = getDatabaseConnection($dbPath);
+$pdo = getDatabaseConnection();
 
 // --- Helper Functions ---
 function safe_filename($name, $max_length = 150) {

--- a/check_db.php
+++ b/check_db.php
@@ -2,10 +2,11 @@
 // check_calibre_db.php
 // Verifies if the database schema matches Calibre's expectations.
 
-$dbPath = 'ebooks/metadata.db';
+require_once __DIR__ . '/db.php';
+$dbPath = currentDatabasePath();
 
 try {
-    $pdo = new PDO("sqlite:$dbPath");
+    $pdo = new PDO('sqlite:' . $dbPath);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     $errors = [];

--- a/custom_column.php
+++ b/custom_column.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'db.php';
-$pdo = new PDO('sqlite:' . getLibraryPath() . '/metadata.db');
+$pdo = getDatabaseConnection();
 // this shows how to create multi-value and single-value calibre multi-value structure for single-value
 // Create single-value column: shelf
 $pdo->exec("

--- a/db.php
+++ b/db.php
@@ -90,24 +90,32 @@ function setUserPreference(string $username, string $key, $value): bool {
 
 function currentDatabasePath(): string {
     $user = currentUser();
+    $path = '';
     if ($user) {
-        $path = getUserPreference($user, 'db_path');
-        if ($path) {
-            return $path;
-        }
+        $path = (string)getUserPreference($user, 'db_path');
     }
-    return getPreference('db_path', 'metadata.old.db');
+    if (!$path) {
+        $path = getPreference('db_path', 'metadata.old.db');
+    }
+    if (!preg_match('/^(?:[\\/]|[A-Za-z]:[\\/])/', $path)) {
+        $path = __DIR__ . '/' . ltrim($path, '/');
+    }
+    return $path;
 }
 
 function getLibraryPath(): string {
     $user = currentUser();
+    $path = '';
     if ($user) {
-        $path = getUserPreference($user, 'library_path');
-        if ($path) {
-            return rtrim($path, '/');
-        }
+        $path = (string)getUserPreference($user, 'library_path');
     }
-    return rtrim(getPreference('library_path', 'ebooks'), '/');
+    if (!$path) {
+        $path = getPreference('library_path', 'ebooks');
+    }
+    if (!preg_match('/^(?:[\\/]|[A-Za-z]:[\\/])/', $path)) {
+        $path = __DIR__ . '/' . ltrim($path, '/');
+    }
+    return rtrim($path, '/');
 }
 
 function bookHasFile(string $relativePath): bool {

--- a/multi_columns.php
+++ b/multi_columns.php
@@ -1,13 +1,12 @@
 <?php
-// Path to your Calibre metadata database
-$dbPath = 'ebooks/metadata.db';
+require_once __DIR__ . '/db.php';
 
 // Column settings (change these two values)
 $columnLabel = 'multi1';        // Internal label (e.g., #multi)
 $columnName  = 'Multi1';        // Display name shown in Calibre
 
 try {
-    $db = new PDO("sqlite:" . $dbPath);
+    $db = getDatabaseConnection();
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     // --------------------------------------------------

--- a/single_columns.php
+++ b/single_columns.php
@@ -1,13 +1,12 @@
 <?php
-// Path to your Calibre metadata database
-$dbPath = 'ebooks/metadata.db';
+require_once __DIR__ . '/db.php';
 
 // Column settings (change these two values)
 $columnLabel = 'mycolumn';   // Internal label (e.g., #mycolumn)
 $columnName  = 'My Column';  // Display name shown in Calibre
 
 try {
-    $db = new PDO("sqlite:" . $dbPath);
+    $db = getDatabaseConnection();
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     // --------------------------------------------------

--- a/test_custom_columns.php
+++ b/test_custom_columns.php
@@ -1,11 +1,8 @@
 <?php
-require 'db.php'; // Include your db.php where the functions are defined
-
-// Path to your Calibre metadata database
-$dbPath = 'ebooks/metadata.db';
+require_once __DIR__ . '/db.php'; // Include your db.php where the functions are defined
 
 try {
-    $pdo = new PDO("sqlite:" . $dbPath);
+    $pdo = getDatabaseConnection();
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     // Run only the initialization code


### PR DESCRIPTION
## Summary
- Anchor database path resolution to project root when preferences provide relative paths.
- Apply the same absolute path handling to library directory retrieval.
- Update utility scripts to rely on centralized path helpers instead of hardcoded relative paths.

## Testing
- `php -l db.php check_db.php single_columns.php multi_columns.php test_custom_columns.php add_book_physical.php custom_column.php`


------
https://chatgpt.com/codex/tasks/task_e_6896189e0cec8329a89ead63f8745608