### PR TITLE
Add helper for web-accessible library path

### DIFF
--- a/db.php
+++ b/db.php
@@ -118,6 +118,15 @@ function getLibraryPath(): string {
     return rtrim($path, '/');
 }
 
+function getLibraryWebPath(): string {
+    $path = getLibraryPath();
+    $docRoot = rtrim($_SERVER['DOCUMENT_ROOT'] ?? '', '/');
+    if ($docRoot && strpos($path, $docRoot) === 0) {
+        $path = substr($path, strlen($docRoot));
+    }
+    return '/' . ltrim($path, '/');
+}
+
 function bookHasFile(string $relativePath): bool {
     $library = getLibraryPath();
     $dir = $library . '/' . $relativePath;


### PR DESCRIPTION
## Summary
- add `getLibraryWebPath()` helper to derive library path relative to web root

## Testing
- `php -l db.php`


------
https://chatgpt.com/codex/tasks/task_e_68961ce32a7083299fe7a3ade588f2ea