### PR TITLE
Fix parsing of rga results in research page

### DIFF
--- a/research.php
+++ b/research.php
@@ -20,6 +20,15 @@ if ($searchTerm !== '') {
                 $currentFile = null;
                 continue;
             }
+            if (preg_match('/^([^:]+):(\d+)([:\-])(.*)$/', $line, $m)) {
+                $currentFile = $m[1];
+                $results[$currentFile][] = [
+                    'line' => (int)$m[2],
+                    'text' => ltrim($m[4]),
+                    'match' => $m[3] === ':'
+                ];
+                continue;
+            }
             if ($currentFile === null) {
                 $currentFile = $line;
                 continue;


### PR DESCRIPTION
## Summary
- Handle `file:line` output from rga so research.php returns matches when headings are omitted

## Testing
- `php -l research.php`


------
https://chatgpt.com/codex/tasks/task_e_68968f8e66a48329a02ab1e9e04ace77