### PR TITLE
Preserve periods in sanitized filenames

### DIFF
--- a/add_book_physical.php
+++ b/add_book_physical.php
@@ -29,7 +29,7 @@ $pdo = getDatabaseConnection();
 
 // --- Helper Functions ---
 function safe_filename($name, $max_length = 150) {
-    $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
+    $name = preg_replace('/[^A-Za-z0-9 _.-]/', '', $name);
     return substr(trim($name), 0, $max_length);
 }
 

--- a/add_physical_book.php
+++ b/add_physical_book.php
@@ -60,7 +60,7 @@ function fetchAdditionalMetadata(string $title, string $author): array {
 }
 
 function safe_filename(string $name, int $max_length = 150): string {
-    $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
+    $name = preg_replace('/[^A-Za-z0-9 _.-]/', '', $name);
     return substr(trim($name), 0, $max_length);
 }
 

--- a/add_physical_books.php
+++ b/add_physical_books.php
@@ -60,7 +60,7 @@ function fetchAdditionalMetadata(string $title, string $author): array {
 }
 
 function safe_filename(string $name, int $max_length = 150): string {
-    $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
+    $name = preg_replace('/[^A-Za-z0-9 _.-]/', '', $name);
     return substr(trim($name), 0, $max_length);
 }
 

--- a/book.php
+++ b/book.php
@@ -3,7 +3,7 @@ require_once 'db.php';
 requireLogin();
 
 function safe_filename(string $name, int $max_length = 150): string {
-    $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
+    $name = preg_replace('/[^A-Za-z0-9 _.-]/', '', $name);
     return substr(trim($name), 0, $max_length);
 }
 

--- a/json_endpoints/add_metadata_book.php
+++ b/json_endpoints/add_metadata_book.php
@@ -76,7 +76,7 @@ function fetchAdditionalMetadata(string $title, string $author): array {
 }
 
 function safe_filename(string $name, int $max_length = 150): string {
-    $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
+    $name = preg_replace('/[^A-Za-z0-9 _.-]/', '', $name);
     return substr(trim($name), 0, $max_length);
 }
 

--- a/json_endpoints/upload_book_file.php
+++ b/json_endpoints/upload_book_file.php
@@ -24,7 +24,7 @@ $wantJson = stripos($accept, 'application/json') !== false ||
             strtolower($reqWith) === 'xmlhttprequest';
 
 function safe_filename(string $name, int $max_length = 150): string {
-    $name = preg_replace('/[^A-Za-z0-9 _-]/', '', $name);
+    $name = preg_replace('/[^A-Za-z0-9 _.-]/', '', $name);
     return substr(trim($name), 0, $max_length);
 }
 


### PR DESCRIPTION
## Summary
- Retain periods in sanitized filenames so author names like "R. Scott Bakker" are not altered during edits or uploads
- Apply the updated regex to book editing and book creation endpoints for consistent directory naming

## Testing
- `php -l book.php`
- `php -l add_book_physical.php`
- `php -l add_physical_book.php`
- `php -l add_physical_books.php`
- `php -l json_endpoints/add_metadata_book.php`
- `php -l json_endpoints/upload_book_file.php`


------
https://chatgpt.com/codex/tasks/task_e_6899f7d5b5a483299799b906ca24a111