### PR TITLE
Add title and series autocomplete to search

### DIFF
--- a/json_endpoints/series_autocomplete.php
+++ b/json_endpoints/series_autocomplete.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @endpoint GET /api/autocomplete_series
+ * @description Fuzzy autocomplete for series names, using substring match and similarity scoring.
+ *
+ * @params
+ *     - term (string, required): Partial series name to search
+ *
+ * @returns JSON array of up to 10 closest matches
+ */
+
+require_once __DIR__ . '/../db.php';
+requireLogin();
+header('Content-Type: application/json');
+
+$term = trim($_GET['term'] ?? '');
+if ($term === '') {
+    echo json_encode([]);
+    exit;
+}
+
+try {
+    $pdo = getDatabaseConnection();
+
+    // Broad match to fetch candidate series names
+    $stmt = $pdo->prepare('SELECT name FROM series WHERE name LIKE :term COLLATE NOCASE');
+    $stmt->execute([':term' => '%' . $term . '%']);
+    $names = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+    // Score by similarity
+    $scored = [];
+    foreach ($names as $name) {
+        $score = similar_text(strtolower($term), strtolower($name));
+        $scored[] = ['name' => $name, 'score' => $score];
+    }
+
+    // Sort by score descending, then name
+    usort($scored, fn($a, $b) =>
+        $b['score'] <=> $a['score'] ?: strcmp($a['name'], $b['name'])
+    );
+
+    // Return just names
+    $result = array_column(array_slice($scored, 0, 10), 'name');
+    echo json_encode($result);
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error']);
+}

--- a/json_endpoints/title_autocomplete.php
+++ b/json_endpoints/title_autocomplete.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @endpoint GET /api/autocomplete_title
+ * @description Fuzzy autocomplete for book titles, using substring match and similarity scoring.
+ *
+ * @params
+ *     - term (string, required): Partial title to search
+ *
+ * @returns JSON array of up to 10 closest matches
+ */
+
+require_once __DIR__ . '/../db.php';
+requireLogin();
+header('Content-Type: application/json');
+
+$term = trim($_GET['term'] ?? '');
+if ($term === '') {
+    echo json_encode([]);
+    exit;
+}
+
+try {
+    $pdo = getDatabaseConnection();
+
+    // Broad match to fetch candidate titles
+    $stmt = $pdo->prepare('SELECT DISTINCT title FROM books WHERE title LIKE :term COLLATE NOCASE');
+    $stmt->execute([':term' => '%' . $term . '%']);
+    $titles = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+    // Score by similarity
+    $scored = [];
+    foreach ($titles as $title) {
+        $score = similar_text(strtolower($term), strtolower($title));
+        $scored[] = ['name' => $title, 'score' => $score];
+    }
+
+    // Sort by score descending, then title
+    usort($scored, fn($a, $b) =>
+        $b['score'] <=> $a['score'] ?: strcmp($a['name'], $b['name'])
+    );
+
+    // Return just titles
+    $result = array_column(array_slice($scored, 0, 10), 'name');
+    echo json_encode($result);
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error']);
+}

--- a/navbar.php
+++ b/navbar.php
@@ -52,7 +52,7 @@ $statusNameVal = isset($statusName) ? $statusName : '';
 
           <div class="input-group position-relative">
             <input class="form-control" type="search" name="search" style="width: 20rem;" placeholder="Search books..." value="<?= htmlspecialchars($searchVal) ?>" aria-label="Search" autocomplete="off">
-            <ul id="authorSuggestions" class="list-group position-absolute w-100" style="z-index:1000; display:none; top:100%; left:0;"></ul>
+            <ul id="searchSuggestions" class="list-group position-absolute w-100" style="z-index:1000; display:none; top:100%; left:0;"></ul>
             <select name="source" class="form-select" style="max-width: 12rem;">
               <option value="local"<?= $sourceVal === 'local' ? ' selected' : '' ?>>Local</option>
               <option value="openlibrary"<?= $sourceVal === 'openlibrary' ? ' selected' : '' ?>>Open Library</option>


### PR DESCRIPTION
## Summary
- expand local search autocomplete beyond authors to include book titles and series names
- fetch and display suggestions with category badges
- add backend endpoints for title and series autocomplete

## Testing
- `php -l json_endpoints/title_autocomplete.php`
- `php -l json_endpoints/series_autocomplete.php`
- `php -l navbar.php`
- `node --check js/search.js`


------
https://chatgpt.com/codex/tasks/task_e_689a8c1409ec83299844c3251dda53ff