### PR TITLE
Handle non-string values in escapeHTML

### DIFF
--- a/js/list_books.js
+++ b/js/list_books.js
@@ -1,9 +1,10 @@
 function escapeHTML(str) {
-  return str.replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function setDescription(el, text) {


### PR DESCRIPTION
## Summary
- Prevent runtime errors by coercing values to strings in `escapeHTML`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e3bbbbc8329a27f48e8989be271