### PR TITLE
Enable series searches in local catalog

### DIFF
--- a/list_books.php
+++ b/list_books.php
@@ -90,6 +90,17 @@ $authorInitial = isset($_GET['author_initial'])
     : '';
 $search = isset($_GET['search']) ? trim((string)$_GET['search']) : '';
 $source = $_GET['source'] ?? 'local';
+
+// If searching locally, redirect to series page when query matches a series name
+if ($search !== '' && $source === 'local') {
+    $stmt = $pdo->prepare('SELECT id FROM series WHERE name = :name COLLATE NOCASE');
+    $stmt->execute([':name' => $search]);
+    $seriesMatch = $stmt->fetchColumn();
+    if ($seriesMatch) {
+        header('Location: list_books.php?series_id=' . (int)$seriesMatch);
+        exit;
+    }
+}
 $redirectParams = $_GET;
 unset($redirectParams['source']);
 if ($source === 'openlibrary') {


### PR DESCRIPTION
## Summary
- revert schema and DB changes from earlier iteration
- redirect local search queries matching a series name to that series' book list

## Testing
- `php -l list_books.php`


------
https://chatgpt.com/codex/tasks/task_e_689a9bdea99883298fc88b774a18551a