### PR TITLE
Add shared navbar for research tools

### DIFF
--- a/research.php
+++ b/research.php
@@ -176,7 +176,7 @@ if ($searchTerm !== '' && $bookDirs) {
     </style>
 </head>
 <body class="pt-5">
-<?php include 'navbar_other.php'; ?>
+<?php include 'research/navbar.php'; ?>
 <div class="container my-4">
     <h1>Research</h1>
 

--- a/research/navbar.php
+++ b/research/navbar.php
@@ -1,0 +1,69 @@
+<?php // Research section navbar ?>
+<nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand d-flex align-items-center" href="/research.php">
+      <i class="fa-solid fa-flask me-2"></i> Research
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResearch" aria-controls="navbarResearch" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarResearch">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="/research.php">Search</a></li>
+        <li class="nav-item"><a class="nav-link" href="/research/research-ask.php">Ask</a></li>
+        <li class="nav-item"><a class="nav-link" href="/research/research-ai.php">AI Ingest</a></li>
+        <li class="nav-item"><a class="nav-link" href="/research/research-verifyPDF.php">Verify PDF</a></li>
+      </ul>
+      <ul class="navbar-nav ms-auto align-items-center">
+        <li class="nav-item me-2">
+          <a class="btn btn-primary" href="/add_physical_book.php">
+            <i class="fa-solid fa-plus me-1"></i> Add Book
+          </a>
+        </li>
+        <li class="nav-item me-2">
+          <a class="btn btn-primary" href="/add_physical_books.php">
+            <i class="fa-solid fa-plus me-1"></i> Add Books
+          </a>
+        </li>
+        <li class="nav-item me-2">
+          <a class="btn btn-primary" href="/notepad.php">
+            <i class="fa-solid fa-pen-nib me-1"></i> WordPro
+          </a>
+        </li>
+        <?php if (function_exists('currentUser') && currentUser()): ?>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="fa-solid fa-user me-1"></i>
+            <?= htmlspecialchars(currentUser()) ?>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+            <li>
+              <a class="dropdown-item" href="/reading_challenges.php">
+                <i class="fa-solid fa-flag-checkered me-1"></i> Reading Challenge
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item" href="/preferences.php">
+                <i class="fa-solid fa-gear me-1"></i> Prefs
+              </a>
+            </li>
+            <li><hr class="dropdown-divider"></li>
+            <li>
+              <a class="dropdown-item" href="/logout.php">
+                <i class="fa-solid fa-right-from-bracket me-1"></i> Logout
+              </a>
+            </li>
+          </ul>
+        </li>
+        <?php else: ?>
+        <li class="nav-item">
+          <a class="btn btn-sm btn-outline-light" href="/login.php">
+            <i class="fa-solid fa-right-to-bracket me-1"></i> Login
+          </a>
+        </li>
+        <?php endif; ?>
+      </ul>
+    </div>
+  </div>
+</nav>
+<script src="../js/navbar.js"></script>

--- a/research/research-ai.php
+++ b/research/research-ai.php
@@ -169,7 +169,8 @@ if (is_file($dbListPath)) {
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/all.min.css" crossorigin="anonymous">
 </head>
-<body>
+<body class="pt-5">
+<?php include 'navbar.php'; ?>
 <div class="container py-4">
 <h1 class="mb-4"><i class="fa-solid fa-file-pdf me-2"></i>Research AI PDF Ingest</h1>
 <form method="POST" enctype="multipart/form-data">

--- a/research/research-ask.php
+++ b/research/research-ask.php
@@ -201,7 +201,8 @@ if ($question !== '') {
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="/css/all.min.css" crossorigin="anonymous">
 </head>
-<body>
+<body class="pt-5">
+<?php include 'navbar.php'; ?>
 <div class="container my-4">
 <h1 class="mb-4"><i class="fa-solid fa-magnifying-glass"></i> Research Ask</h1>
 <form method="post" class="mb-4">

--- a/research/research-verifyPDF.php
+++ b/research/research-verifyPDF.php
@@ -84,7 +84,8 @@ if ($itemId) {
 <title>Verify PDF Pages</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
 </head>
-<body class="p-3">
+<body class="p-3 pt-5">
+<?php include 'navbar.php'; ?>
 <h1 class="mb-4">Verify PDF Page Numbers</h1>
 <form method="post" enctype="multipart/form-data" class="mb-4">
   <div class="mb-3">


### PR DESCRIPTION
## Summary
- Provide a dedicated navbar for the research pages with links to Search, Ask, AI Ingest, and Verify PDF utilities.
- Use the new navbar across `research.php` and the research subpages for consistent navigation.

## Testing
- `php -l research/navbar.php research.php research/research-ai.php research/research-ask.php research/research-verifyPDF.php`


------
https://chatgpt.com/codex/tasks/task_e_689da51626c88329b26a88df5008f1be