### PR TITLE
feat: add page label mapping to web ingestion

### DIFF
--- a/library_schema.sql
+++ b/library_schema.sql
@@ -14,7 +14,11 @@ CREATE TABLE chunks (
   page_end INTEGER,
   text TEXT NOT NULL,
   embedding BLOB,                 -- store as binary-packed floats (smaller) or JSON
-  token_count INTEGER, display_start INTEGER, display_end   INTEGER,
+  token_count INTEGER,
+  display_start INTEGER,
+  display_end INTEGER,
+  display_start_label TEXT,
+  display_end_label TEXT,
   FOREIGN KEY(item_id) REFERENCES items(id)
 );
 CREATE INDEX idx_chunks_item ON chunks(item_id);

--- a/research/extract_page_labels.py
+++ b/research/extract_page_labels.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import sys, json
+
+try:
+    from pypdf import PdfReader
+except Exception:
+    # pypdf not installed or cannot import; output empty mapping
+    print("{}")
+    sys.exit(0)
+
+if len(sys.argv) < 2:
+    print("{}")
+    sys.exit(0)
+
+path = sys.argv[1]
+try:
+    reader = PdfReader(path)
+except Exception:
+    print("{}")
+    sys.exit(0)
+
+labels = {}
+for i in range(len(reader.pages)):
+    try:
+        lbl = reader.get_page_label(i)
+    except Exception:
+        lbl = None
+    if lbl is not None:
+        labels[str(i + 1)] = str(lbl)
+
+print(json.dumps(labels, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- integrate built-in and heuristic page label mapping into research ingestion flow
- store display labels for chunks and recompute citation ranges automatically
- restore CLI ingest script to its original simplified form

## Testing
- `php -l research/research-ai.php`
- `php -l research/review-pages.php`
- `python3 -m py_compile research/extract_page_labels.py`


------
https://chatgpt.com/codex/tasks/task_e_689e3945e3d483299e022605403f2690