### PR TITLE
Link research references to library PDFs

### DIFF
--- a/library_schema.sql
+++ b/library_schema.sql
@@ -3,8 +3,10 @@ CREATE TABLE items (
   title TEXT NOT NULL,
   author TEXT,
   year INTEGER,
+  display_offset INTEGER DEFAULT 0,
+  library_book_id INTEGER,
   created_at TEXT DEFAULT CURRENT_TIMESTAMP
-, display_offset INTEGER DEFAULT 0);
+);
 CREATE TABLE sqlite_sequence(name,seq);
 CREATE TABLE chunks (
   id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- Allow entering a Library Book ID when ingesting PDFs so it is stored in the `items` table.
- Include library book IDs in QA retrieval and resolve them to direct PDF links for each cited source.
- Update schema definition to document new `library_book_id` column.

## Testing
- `php -l research/research-ai.php`
- `php -l research/research-ask.php`


------
https://chatgpt.com/codex/tasks/task_e_689e6c2a89e48329959651c0b1cd75e2