### PR TITLE
Fix Research Ask note lookup

### DIFF
--- a/research/research-ask.php
+++ b/research/research-ask.php
@@ -51,11 +51,18 @@ $bookList = [];
 // Fetch list of existing notes for saving answers
 $noteList = [];
 try {
+    // Books are stored in the embedding database used for retrieval
     $dbList = new PDO('sqlite:' . __DIR__ . '/../library.sqlite');
     $stmt = $dbList->query('SELECT id, title FROM items ORDER BY title');
     $bookList = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (Exception $e) {
+    // Ignore if the database is unavailable
+}
 
-    $noteStmt = $dbList->query('SELECT id, title FROM notepad ORDER BY title');
+try {
+    // Notes live in the main metadata database
+    $noteDb = getDatabaseConnection();
+    $noteStmt = $noteDb->query('SELECT id, title FROM notepad ORDER BY title');
     $noteList = $noteStmt->fetchAll(PDO::FETCH_ASSOC);
 } catch (Exception $e) {
     // Ignore if the database is unavailable


### PR DESCRIPTION
## Summary
- Query notes using the main Calibre database instead of the embedding database so existing notes appear when saving answers.

## Testing
- `php -l research/research-ask.php`


------
https://chatgpt.com/codex/tasks/task_e_689ee7c29624832993b6aadbb6c72200