### PR TITLE
Add Harvard referencing conversion option to notepad

### DIFF
--- a/json_endpoints/convert_reference_style.php
+++ b/json_endpoints/convert_reference_style.php
@@ -1,0 +1,84 @@
+<?php
+header('Content-Type: application/json');
+require_once __DIR__ . '/../db.php';
+requireLogin();
+
+$id    = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$style = $_POST['style'] ?? 'harvard';
+if ($id <= 0 || $style !== 'harvard') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid parameters']);
+    exit;
+}
+
+$pdo = getDatabaseConnection();
+$stmt = $pdo->prepare('SELECT text FROM notepad WHERE id = ?');
+$stmt->execute([$id]);
+$note = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$note) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Note not found']);
+    exit;
+}
+
+$html = $note['text'];
+
+$apiKey = getenv('OPENROUTER_API_KEY');
+if (!$apiKey) {
+    // Without an API key we cannot convert; return original text.
+    echo json_encode(['status' => 'error', 'error' => 'Missing API key', 'text' => $html]);
+    exit;
+}
+
+$payload = [
+    'model' => 'anthropic/claude-sonnet-4',
+    'messages' => [
+        [
+            'role' => 'system',
+            'content' => 'Convert Oxford-style footnote citations in the provided HTML into Harvard referencing with in-text citations.'
+        ],
+        [
+            'role' => 'user',
+            'content' => $html
+        ]
+    ],
+    'temperature' => 0.2,
+    'max_tokens' => 2000
+];
+
+$ch = curl_init('https://openrouter.ai/api/v1/chat/completions');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    "Authorization: Bearer {$apiKey}",
+    'Content-Type: application/json'
+]);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+
+$response = curl_exec($ch);
+if ($response === false) {
+    $error = curl_error($ch);
+    curl_close($ch);
+    echo json_encode(['status' => 'error', 'error' => $error, 'text' => $html]);
+    exit;
+}
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+if ($code >= 400) {
+    echo json_encode(['status' => 'error', 'error' => 'API request failed', 'text' => $html]);
+    exit;
+}
+
+$data = json_decode($response, true);
+$newText = $data['choices'][0]['message']['content'] ?? '';
+if ($newText === '') {
+    echo json_encode(['status' => 'error', 'error' => 'Invalid API response', 'text' => $html]);
+    exit;
+}
+
+$stmt = $pdo->prepare('UPDATE notepad SET text = ?, last_edited = CURRENT_TIMESTAMP WHERE id = ?');
+$stmt->execute([$newText, $id]);
+
+echo json_encode(['status' => 'ok', 'text' => $newText]);
+?>

--- a/notepad.php
+++ b/notepad.php
@@ -299,11 +299,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
             <div class="bg-white p-4 shadow rounded">
                 <h2><?= $title ?></h2>
-                <div><?= $text ?></div>
+                <div id="noteContent"><?= $text ?></div>
                 <div class="d-flex justify-content-between align-items-center mt-3 no-print">
                     <a href="notepad.php" class="btn btn-secondary">Back</a>
                     <div>
                         <button type="button" onclick="window.print()" class="btn btn-outline-secondary me-2">Print</button>
+                        <button type="button" id="convertHarvardBtn" class="btn btn-outline-secondary me-2">Change to Harvard</button>
                         <a href="notepad.php?id=<?= (int)$id ?>" class="btn btn-primary">Edit</a>
                     </div>
                 </div>
@@ -398,6 +399,32 @@ document.addEventListener('DOMContentLoaded', function () {
             <?php endif; ?>
         <?php endif; ?>
     </div>
+
+    <?php if ($action === 'view' && $id > 0): ?>
+    <script>
+    document.getElementById('convertHarvardBtn')?.addEventListener('click', async () => {
+        const btn = document.getElementById('convertHarvardBtn');
+        const noteEl = document.getElementById('noteContent');
+        btn.disabled = true;
+        btn.textContent = 'Converting...';
+        try {
+            const res = await fetch('json_endpoints/convert_reference_style.php', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: new URLSearchParams({ id: <?= (int)$id ?>, style: 'harvard' })
+            });
+            const data = await res.json();
+            if (data.status === 'ok' && data.text) {
+                noteEl.innerHTML = data.text;
+            }
+        } catch (err) {
+            console.error(err);
+        }
+        btn.disabled = false;
+        btn.textContent = 'Change to Harvard';
+    });
+    </script>
+    <?php endif; ?>
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- Add UI button on note view to convert Oxford-style citations to Harvard
- Implement client-side script to request citation style conversion via AJAX
- Introduce backend endpoint using OpenRouter to transform references and update note

## Testing
- `php -l notepad.php`
- `php -l json_endpoints/convert_reference_style.php`


------
https://chatgpt.com/codex/tasks/task_e_689f1184784c8329be969213777f0287