### PR TITLE
Handle quotes before footnote markers

### DIFF
--- a/notepad.php
+++ b/notepad.php
@@ -453,7 +453,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         // Replace in-text markers with Harvard-style references
-        container.innerHTML = container.innerHTML.replace(/\[\^(\d+)\]/g, (match, num) => {
+        container.innerHTML = container.innerHTML.replace(/(["”])?\[\^(\d+)\]/g, (match, quote, num) => {
             const info = map[num];
             if (!info) return match;
             let citation = '';
@@ -464,7 +464,7 @@ document.addEventListener('DOMContentLoaded', function () {
             } else if (info.raw) {
                 citation = '(' + info.raw + ')';
             }
-            return `<span class="reference">${citation}</span>`;
+            return `${quote || ''}<span class="reference">${citation}</span>`;
         });
 
         // Clean up any empty paragraphs left over after removing footnotes


### PR DESCRIPTION
## Summary
- allow Harvard footnote conversion when markers follow a closing quote

## Testing
- `php -l notepad.php`
- `node - <<'NODE'
const map = {6:{author:'Doe',year:'2020'}};
let container = {innerHTML: '"[^6]'};
container.innerHTML = container.innerHTML.replace(/(["”])?\\[\\^(\\d+)\\]/g, (match, quote, num) => {
  const info = map[num];
  if (!info) return match;
  let citation = '';
  if (info.author && info.year) {
    citation = '(' + info.author + ' ' + info.year + ')';
  } else if (info.raw) {
    citation = '(' + info.raw + ')';
  }
  return `${quote || ''}<span class=\"reference\">${citation}</span>`;
});
console.log(container.innerHTML);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689f1d1e3cf0832982060bc339d3f2d4