### PR TITLE
feat: add lightweight notes app

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Personal writing is kept in its own `notepad` table. This table is unrelated to
 any Calibre book and simply stores an `id`, `title`, the full `text`, the
 creation `time` and the `last_edited` timestamp. It is created automatically
 when the database is opened if it does not already exist.
-Open `notepad.php` to create or edit entries using the same TinyMCE editor used
-for book notes.
+Open the lightweight notes app at `/notes/` to create or edit entries using the
+same TinyMCE editor used for book notes. The backend exposes JSON endpoints for
+listing, reading and saving notes, and the front-end keeps track of the current
+note in `localStorage`.
 
 Genres are stored in the custom column labeled `genre` and listed in the sidebar. You can add,
 rename or delete genres from that list just like shelves and status values.

--- a/irc_search.html
+++ b/irc_search.html
@@ -40,7 +40,7 @@
 
         <!-- WordPro Button -->
         <li class="nav-item me-2">
-          <a class="btn btn-primary" href="/notepad.php">
+          <a class="btn btn-primary" href="/notes/">
             <i class="fa-solid fa-pen-nib me-1"></i> WordPro
           </a>
         </li>
@@ -87,7 +87,7 @@
 
         <!-- WordPro Button -->
         <li class="nav-item me-2">
-          <a class="btn btn-primary" href="/notepad.php">
+          <a class="btn btn-primary" href="/notes/">
             <i class="fa-solid fa-pen-nib me-1"></i> WordPro
           </a>
         </li>

--- a/ircdashboard.html
+++ b/ircdashboard.html
@@ -106,7 +106,7 @@
 
         <!-- WordPro Button -->
         <li class="nav-item me-2">
-          <a class="btn btn-primary" href="/notepad.php">
+          <a class="btn btn-primary" href="/notes/">
             <i class="fa-solid fa-pen-nib me-1"></i> WordPro
           </a>
         </li>

--- a/ircdashboard.php
+++ b/ircdashboard.php
@@ -43,7 +43,7 @@
 
         <!-- WordPro Button -->
         <li class="nav-item me-2">
-          <a class="btn btn-primary" href="/notepad.php">
+          <a class="btn btn-primary" href="/notes/">
             <i class="fa-solid fa-pen-nib me-1"></i> WordPro
           </a>
         </li>

--- a/navbar.php
+++ b/navbar.php
@@ -108,7 +108,7 @@ $statusNameVal = isset($statusName) ? $statusName : '';
 
         <!-- WordPro Button -->
         <li class="nav-item me-2">
-          <a class="btn btn-primary" href="/notepad.php">
+          <a class="btn btn-primary" href="/notes/">
             <i class="fa-solid fa-pen-nib me-1"></i> WordPro
           </a>
         </li>

--- a/navbar_other.php
+++ b/navbar_other.php
@@ -37,7 +37,7 @@
 
         <!-- WordPro Button -->
         <li class="nav-item me-2">
-          <a class="btn btn-primary" href="/notepad.php">
+          <a class="btn btn-primary" href="/notes/">
             <i class="fa-solid fa-pen-nib me-1"></i> WordPro
           </a>
         </li>

--- a/notes/api.php
+++ b/notes/api.php
@@ -1,0 +1,73 @@
+<?php
+require_once '../db.php';
+requireLogin();
+
+$pdo = getDatabaseConnection();
+
+// Ensure FTS table and triggers exist for search
+$pdo->exec("CREATE VIRTUAL TABLE IF NOT EXISTS notepad_fts USING fts5(title, text, content='notepad', content_rowid='id')");
+$pdo->exec("CREATE TRIGGER IF NOT EXISTS notepad_ai AFTER INSERT ON notepad BEGIN
+    INSERT INTO notepad_fts(rowid, title, text) VALUES (new.id, new.title, new.text);
+END;");
+$pdo->exec("CREATE TRIGGER IF NOT EXISTS notepad_au AFTER UPDATE ON notepad BEGIN
+    INSERT INTO notepad_fts(notepad_fts, rowid, title, text) VALUES('delete', old.id, old.title, old.text);
+    INSERT INTO notepad_fts(rowid, title, text) VALUES (new.id, new.title, new.text);
+END;");
+$pdo->exec("CREATE TRIGGER IF NOT EXISTS notepad_ad AFTER DELETE ON notepad BEGIN
+    INSERT INTO notepad_fts(notepad_fts, rowid, title, text) VALUES('delete', old.id, old.title, old.text);
+END;");
+
+$method = $_SERVER['REQUEST_METHOD'];
+$path = trim($_SERVER['PATH_INFO'] ?? '', '/');
+
+header('Content-Type: application/json');
+
+if ($method === 'GET' && $path === '') {
+    $q = trim($_GET['q'] ?? '');
+    if ($q !== '') {
+        $stmt = $pdo->prepare("SELECT n.id, n.title, snippet(notepad_fts, 1, '<mark>', '</mark>', '...', 10) AS snippet
+                               FROM notepad_fts
+                               JOIN notepad n ON n.id = notepad_fts.rowid
+                               WHERE notepad_fts MATCH ?
+                               ORDER BY rank");
+        $stmt->execute([$q]);
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+    } else {
+        $stmt = $pdo->query('SELECT id, title, last_edited FROM notepad ORDER BY last_edited DESC');
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+    exit;
+}
+
+if ($method === 'GET' && ctype_digit($path)) {
+    $stmt = $pdo->prepare('SELECT id, title, text, last_edited FROM notepad WHERE id = ?');
+    $stmt->execute([$path]);
+    $note = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($note) {
+        echo json_encode($note);
+    } else {
+        http_response_code(404);
+        echo json_encode(['error' => 'Not found']);
+    }
+    exit;
+}
+
+if ($method === 'POST' && ctype_digit($path)) {
+    $data = json_decode(file_get_contents('php://input'), true) ?: [];
+    $title = trim($data['title'] ?? 'Untitled');
+    $text  = $data['text'] ?? '';
+
+    if ($path === '0') {
+        $stmt = $pdo->prepare('INSERT INTO notepad (title, text) VALUES (?, ?)');
+        $stmt->execute([$title, $text]);
+        echo json_encode(['id' => (int)$pdo->lastInsertId()]);
+    } else {
+        $stmt = $pdo->prepare('UPDATE notepad SET title = ?, text = ?, last_edited = CURRENT_TIMESTAMP WHERE id = ?');
+        $stmt->execute([$title, $text, $path]);
+        echo json_encode(['id' => (int)$path]);
+    }
+    exit;
+}
+
+http_response_code(400);
+echo json_encode(['error' => 'Bad request']);

--- a/notes/index.php
+++ b/notes/index.php
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Notes</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/tinymce@6/tinymce.min.js" referrerpolicy="origin"></script>
+</head>
+<body class="vh-100 d-flex">
+    <div id="sidebar" class="border-end p-2" style="width:250px; overflow-y:auto;">
+        <button id="newNote" class="btn btn-sm btn-success w-100 mb-2">New Note</button>
+        <ul id="noteList" class="list-group"></ul>
+    </div>
+    <div class="flex-grow-1 d-flex flex-column">
+        <div id="topBar" class="border-bottom p-1 d-flex align-items-center">
+            <div id="openTabs" class="flex-grow-1"></div>
+            <button id="saveBtn" class="btn btn-sm btn-success me-2">Save</button>
+            <button id="viewBtn" class="btn btn-sm btn-outline-secondary">View</button>
+        </div>
+        <div id="editorPane" class="flex-grow-1 position-relative">
+            <textarea id="editor"></textarea>
+            <div id="viewer" class="h-100 w-100 overflow-auto p-2" style="display:none;"></div>
+        </div>
+    </div>
+<script>
+    tinymce.init({ selector:'#editor', height:'100%', menubar:false, branding:false });
+
+    const notesCache = {};
+    const openNotes = [];
+    let activeId = null;
+    let viewing = false;
+
+    async function loadList(q='') {
+        const url = q ? `api.php?q=${encodeURIComponent(q)}` : 'api.php';
+        const res = await fetch(url);
+        const data = await res.json();
+        const list = document.getElementById('noteList');
+        list.innerHTML = '';
+        data.forEach(n => {
+            const li = document.createElement('li');
+            li.className = 'list-group-item list-group-item-action';
+            li.textContent = n.title;
+            li.onclick = () => openNote(n.id);
+            list.appendChild(li);
+        });
+    }
+
+    async function openNote(id) {
+        if (!notesCache[id]) {
+            const res = await fetch('api.php/' + id);
+            if (!res.ok) return;
+            notesCache[id] = await res.json();
+        }
+        if (!openNotes.includes(id)) {
+            openNotes.push(id);
+            renderTabs();
+        }
+        activeId = id;
+        tinymce.get('editor').setContent(notesCache[id].text || '');
+        localStorage.setItem('currentNote', id);
+        highlightTabs();
+        if (viewing) {
+            document.getElementById('viewer').style.display = 'none';
+            tinymce.get('editor').getContainer().style.display = '';
+            document.getElementById('viewBtn').textContent = 'View';
+            document.getElementById('saveBtn').disabled = false;
+            viewing = false;
+        }
+    }
+
+    function renderTabs() {
+        const tabs = document.getElementById('openTabs');
+        tabs.innerHTML = '';
+        openNotes.forEach(id => {
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-sm btn-outline-secondary me-1';
+            btn.textContent = notesCache[id]?.title || ('Note ' + id);
+            btn.onclick = () => openNote(id);
+            tabs.appendChild(btn);
+        });
+        highlightTabs();
+    }
+
+    function highlightTabs() {
+        const tabs = document.getElementById('openTabs').children;
+        for (let i = 0; i < tabs.length; i++) {
+            const id = openNotes[i];
+            tabs[i].classList.toggle('btn-primary', id === activeId);
+            tabs[i].classList.toggle('btn-outline-secondary', id !== activeId);
+        }
+    }
+
+    async function saveNote() {
+        if (!activeId) return;
+        const content = tinymce.get('editor').getContent();
+        const title = notesCache[activeId]?.title || 'Untitled';
+        await fetch('api.php/' + activeId, {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({title, text: content})
+        });
+        notesCache[activeId].text = content;
+        loadList();
+    }
+
+    async function toggleView() {
+        if (!activeId) return;
+        const viewer = document.getElementById('viewer');
+        const editor = tinymce.get('editor');
+        const btn = document.getElementById('viewBtn');
+        if (!viewing) {
+            const res = await fetch('api.php/' + activeId);
+            if (!res.ok) return;
+            const data = await res.json();
+            notesCache[activeId] = data;
+            viewer.innerHTML = data.text || '';
+            viewer.style.display = 'block';
+            editor.getContainer().style.display = 'none';
+            btn.textContent = 'Edit';
+            document.getElementById('saveBtn').disabled = true;
+            viewing = true;
+        } else {
+            viewer.style.display = 'none';
+            editor.getContainer().style.display = '';
+            btn.textContent = 'View';
+            document.getElementById('saveBtn').disabled = false;
+            viewing = false;
+        }
+    }
+
+    document.addEventListener('keydown', e => {
+        if (e.ctrlKey && e.key === 's') {
+            e.preventDefault();
+            saveNote();
+        }
+        if (e.altKey && e.key >= '1' && e.key <= '9') {
+            const idx = parseInt(e.key) - 1;
+            if (openNotes[idx]) openNote(openNotes[idx]);
+        }
+    });
+
+    document.getElementById('saveBtn').onclick = saveNote;
+    document.getElementById('viewBtn').onclick = toggleView;
+
+    document.getElementById('newNote').onclick = async () => {
+        const title = prompt('Title for new note');
+        const res = await fetch('api.php/0', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({title: title || 'Untitled', text: ''}) });
+        const data = await res.json();
+        await loadList();
+        openNote(data.id);
+    };
+
+    loadList();
+    const last = localStorage.getItem('currentNote');
+    if (last) openNote(parseInt(last));
+</script>
+</body>
+</html>

--- a/research/navbar.php
+++ b/research/navbar.php
@@ -27,7 +27,7 @@
           </a>
         </li>
         <li class="nav-item me-2">
-          <a class="btn btn-primary" href="/notepad.php">
+          <a class="btn btn-primary" href="/notes/">
             <i class="fa-solid fa-pen-nib me-1"></i> WordPro
           </a>
         </li>


### PR DESCRIPTION
## Summary
- Add `/notes` single-page app with TinyMCE editor and open note tabs
- Provide PHP JSON API for listing, reading, searching and saving notes with FTS5
- Redirect WordPro links in navbars and docs to new notes app
- Add save button and AJAX-powered view toggle to notes UI

## Testing
- `php -l notes/index.php`
- `php -l notes/api.php`


------
https://chatgpt.com/codex/tasks/task_e_689f827f0f188329aa967932d5bfff8e