### PR TITLE
Add chunks FTS bootstrap and backfill

### DIFF
--- a/research/research-ai.php
+++ b/research/research-ai.php
@@ -154,6 +154,8 @@ CREATE TABLE IF NOT EXISTS page_map (
 ");
     ensure_chunk_label_cols($db);
     ensure_library_book_id_col($db);
+    ensure_chunks_fts($db);
+    backfill_chunks_fts($db);
     out('Database ready.');
 
     // ---- Page count via pdfinfo ----
@@ -498,6 +500,83 @@ function ensure_library_book_id_col(PDO $db): void {
   if (!in_array('library_book_id', $names, true)) {
     $db->exec("ALTER TABLE items ADD COLUMN library_book_id INTEGER");
   }
+}
+
+function chunk_pages_case_sql(string $alias): string {
+  $alias = trim($alias);
+  if ($alias !== '') {
+    $alias = rtrim($alias, '.') . '.';
+  }
+  return "CASE\n"
+       . "      WHEN {$alias}display_start_label IS NOT NULL AND {$alias}display_end_label IS NOT NULL\n"
+       . "           AND {$alias}display_start_label <> {$alias}display_end_label\n"
+       . "        THEN {$alias}display_start_label || '–' || {$alias}display_end_label\n"
+       . "      WHEN {$alias}page_start IS NOT NULL AND {$alias}page_end IS NOT NULL AND {$alias}page_start <> {$alias}page_end\n"
+       . "        THEN printf('%d–%d', {$alias}page_start, {$alias}page_end)\n"
+       . "      WHEN {$alias}page_start IS NOT NULL\n"
+       . "        THEN CAST({$alias}page_start AS TEXT)\n"
+       . "      ELSE ''\n"
+       . "    END";
+}
+
+function ensure_chunks_fts(PDO $db): void {
+  $db->exec("CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(\n"
+    . "  id UNINDEXED,\n"
+    . "  item_id UNINDEXED,\n"
+    . "  pages UNINDEXED,\n"
+    . "  text,\n"
+    . "  tokenize='porter'\n"
+    . ");");
+
+  $db->exec("DROP TRIGGER IF EXISTS chunks_ai;");
+  $db->exec("DROP TRIGGER IF EXISTS chunks_ad;");
+  $db->exec("DROP TRIGGER IF EXISTS chunks_au;");
+
+  $caseNew = chunk_pages_case_sql('new');
+  $db->exec("CREATE TRIGGER chunks_ai AFTER INSERT ON chunks BEGIN\n"
+    . "  INSERT INTO chunks_fts(rowid, id, text, item_id, pages)\n"
+    . "  VALUES (\n"
+    . "    new.id,\n"
+    . "    new.id,\n"
+    . "    new.text,\n"
+    . "    new.item_id,\n"
+    . "    {$caseNew}\n"
+    . "  );\n"
+    . "END;");
+
+  $db->exec("CREATE TRIGGER chunks_ad AFTER DELETE ON chunks BEGIN\n"
+    . "  INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES('delete', old.id, old.text);\n"
+    . "END;");
+
+  $db->exec("CREATE TRIGGER chunks_au AFTER UPDATE ON chunks BEGIN\n"
+    . "  INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES('delete', old.id, old.text);\n"
+    . "  INSERT INTO chunks_fts(rowid, id, text, item_id, pages)\n"
+    . "  VALUES (\n"
+    . "    new.id,\n"
+    . "    new.id,\n"
+    . "    new.text,\n"
+    . "    new.item_id,\n"
+    . "    {$caseNew}\n"
+    . "  );\n"
+    . "END;");
+}
+
+function backfill_chunks_fts(PDO $db): void {
+  if (!table_exists($db, 'chunks') || !table_exists($db, 'chunks_fts')) {
+    return;
+  }
+
+  $caseExisting = chunk_pages_case_sql('c');
+  $db->exec("INSERT INTO chunks_fts(rowid, id, text, item_id, pages)\n"
+    . "SELECT c.id,\n"
+    . "       c.id,\n"
+    . "       c.text,\n"
+    . "       c.item_id,\n"
+    . "       {$caseExisting}\n"
+    . "FROM chunks c\n"
+    . "WHERE NOT EXISTS (\n"
+    . "    SELECT 1 FROM chunks_fts f WHERE f.rowid = c.id\n"
+    . ");");
 }
 
 function roman_to_int(string $roman): int {


### PR DESCRIPTION
## Summary
- ensure both web and CLI ingestion scripts provision the chunks_fts FTS5 table plus maintenance triggers
- add a reusable helper to compute the display page label and backfill existing chunk rows into the FTS index

## Testing
- php -l research-ai.php
- php -l research/research-ai.php
- sqlite3 /workspace/sqlite-books/library.sqlite "SELECT id, text FROM chunks_fts WHERE chunks_fts MATCH 'databases'"
- php research/research-ask.php > /tmp/ask.html


------
https://chatgpt.com/codex/tasks/task_e_68ce5c8494c48329ac5a4aba20d50085