### PR TITLE
Fix author rename to use filesystem paths

### DIFF
--- a/book.php
+++ b/book.php
@@ -307,13 +307,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $newPath = $newAuthorFolder . '/' . $oldBookFolder;
 
         if ($newPath !== $oldPath) {
-            $libraryPath = getLibraryWebPath();
+            $libraryPath = rtrim(getLibraryPath(), '/');
             $oldFullPath = $oldPath !== '' ? $libraryPath . '/' . $oldPath : '';
             $newFullPath = $libraryPath . '/' . $newPath;
+            $newAuthorDir = dirname($newFullPath);
 
             // Create target author directory if needed
-            if (!is_dir(dirname($newFullPath))) {
-                mkdir(dirname($newFullPath), 0777, true);
+            if (!is_dir($newAuthorDir)) {
+                mkdir($newAuthorDir, 0777, true);
             }
 
             // Move existing directory if present
@@ -321,8 +322,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 rename($oldFullPath, $newFullPath);
 
                 // Remove old author directory if empty
-                $oldAuthorDir = $libraryPath . '/' . $oldAuthorFolder;
-                if (is_dir($oldAuthorDir)) {
+                $oldAuthorDir = $oldAuthorFolder !== '' ? $libraryPath . '/' . $oldAuthorFolder : '';
+                if ($oldAuthorDir !== '' && is_dir($oldAuthorDir)) {
                     $entries = array_diff(scandir($oldAuthorDir), ['.', '..']);
                     if (count($entries) === 0) {
                         rmdir($oldAuthorDir);


### PR DESCRIPTION
## Summary
- switch the author rename logic in book.php to use filesystem library paths
- guard directory operations so they only run against resolved filesystem locations

## Testing
- php <<'PHP'
<?php
function safe_filename(string $name, int $max_length = 150): string {
    $name = preg_replace('/[^A-Za-z0-9 _.-]/', '', $name);
    return substr(trim($name), 0, $max_length);
}
$base = __DIR__ . '/ebooks';
if (is_dir($base)) {
    $it = new RecursiveDirectoryIterator($base, FilesystemIterator::SKIP_DOTS);
    $ri = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::CHILD_FIRST);
    foreach ($ri as $file) {
        if ($file->isDir()) {
            rmdir($file->getPathname());
        } else {
            unlink($file->getPathname());
        }
    }
    rmdir($base);
}
mkdir($base . '/Old Author/Book Title (1)', 0777, true);
$oldPath = 'Old Author/Book Title (1)';
$authorsList = ['New Author'];
$title = 'Book Title';
$id = 1;
$primaryAuthor = $authorsList[0];
$oldBookFolder = $oldPath !== '' ? basename($oldPath) : safe_filename($title) . ' (' . $id . ')';
$oldAuthorFolder = $oldPath !== '' ? dirname($oldPath) : '';
$newAuthorFolder = safe_filename($primaryAuthor . (count($authorsList) > 1 ? ' et al.' : ''));
$newPath = $newAuthorFolder . '/' . $oldBookFolder;
$libraryPath = rtrim($base, '/');
if ($newPath !== $oldPath) {
    $oldFullPath = $oldPath !== '' ? $libraryPath . '/' . $oldPath : '';
    $newFullPath = $libraryPath . '/' . $newPath;
    $newAuthorDir = dirname($newFullPath);
    if (!is_dir($newAuthorDir)) {
        mkdir($newAuthorDir, 0777, true);
    }
    if ($oldFullPath !== '' && is_dir($oldFullPath)) {
        rename($oldFullPath, $newFullPath);
        $oldAuthorDir = $oldAuthorFolder !== '' ? $libraryPath . '/' . $oldAuthorFolder : '';
        if ($oldAuthorDir !== '' && is_dir($oldAuthorDir)) {
            $entries = array_diff(scandir($oldAuthorDir), ['.', '..']);
            if (count($entries) === 0) {
                rmdir($oldAuthorDir);
            }
        }
    } elseif (!is_dir($newFullPath)) {
        mkdir($newFullPath, 0777, true);
    }
}
$results = [
    'new_dir_exists' => is_dir($libraryPath . '/' . $newPath),
    'old_author_exists' => is_dir($libraryPath . '/' . $oldAuthorFolder)
];
var_export($results);
PHP

------
https://chatgpt.com/codex/tasks/task_e_68ce735fa624832984daf5e7a37ac5c1